### PR TITLE
Ruleset actor types

### DIFF
--- a/src/components/reroll/rulesets/ActorTypeInput.module.scss
+++ b/src/components/reroll/rulesets/ActorTypeInput.module.scss
@@ -1,0 +1,3 @@
+.active {
+  background-color: lightblue;
+}

--- a/src/components/reroll/rulesets/ActorTypeInput.tsx
+++ b/src/components/reroll/rulesets/ActorTypeInput.tsx
@@ -1,0 +1,83 @@
+import { Button } from "@owl-factory/components/button";
+import { getUniques } from "@owl-factory/utilities/arrays";
+import React from "react";
+import { ActorType } from "types/documents";
+import { getNextUntitled } from "utilities/helpers";
+
+interface ActorTypeProps {
+  actorTypes: ActorType[];
+  setActorTypes: (actorTypes: ActorType[]) => void;
+  activeType: string | undefined;
+  setActiveType: (activeType: string | undefined) => void;
+}
+
+function ActorTypeList(props: ActorTypeProps) {
+  const rows: JSX.Element[] = [];
+
+  for (const actorType of props.actorTypes) {
+    rows.push(
+      <div key={actorType.key}>
+        {actorType.name} ({actorType.key})
+      </div>
+    );
+  }
+
+  function add() {
+    const actorTypes = [...props.actorTypes];
+    const keys = getUniques(actorTypes, "key");
+    const untitled = getNextUntitled(keys);
+    const newActorType: ActorType = {
+      name: "Untitled",
+      key: untitled,
+      description: "",
+      actorSheet: { ref: "" },
+    };
+    actorTypes.push(newActorType);
+    props.setActorTypes(actorTypes);
+  }
+
+  function remove() {
+    return;
+  }
+
+  return (
+    <div style={{ borderStyle: "dashed", borderWidth: 1, flexGrow: 1 }}>
+      <div>
+        <Button onClick={remove}>-</Button>
+        <Button onClick={add}>+</Button>
+      </div>
+      {rows}
+    </div>
+  );
+}
+
+function ActorTypeForm(props: ActorTypeProps) {
+  const style = { flexGrow: 1};
+
+  return (
+    <div style={style}>
+      Form
+    </div>
+  )
+}
+
+interface ActorTypeInputProps {
+  actorTypes: ActorType[];
+  setActorTypes: (actorTypes: ActorType[]) => void;
+}
+
+export function ActorTypeInput(props: ActorTypeInputProps) {
+  const [ activeType, setActiveType ] = React.useState<string | undefined>();
+
+  return (
+    <div>
+      <h2>Actor Types</h2>
+      <i>Defines the different types of actors / characters used within a game, such as PCs and NPCs.</i>
+
+      <div style={{ display: "flex" }}>
+        <ActorTypeList {...props} activeType={activeType} setActiveType={setActiveType}/>
+        <ActorTypeForm {...props} activeType={activeType} setActiveType={setActiveType}/>
+      </div>
+    </div>
+  );
+}

--- a/src/components/reroll/rulesets/ActorTypeInput.tsx
+++ b/src/components/reroll/rulesets/ActorTypeInput.tsx
@@ -1,43 +1,80 @@
 import { Button } from "@owl-factory/components/button";
+import { Input, Select } from "@owl-factory/components/form";
 import { getUniques } from "@owl-factory/utilities/arrays";
+import { ActorSheetData } from "controllers/data/ActorSheetData";
+import { Formik, FormikProps } from "formik";
+import { useRouter } from "next/router";
 import React from "react";
 import { ActorType } from "types/documents";
 import { getNextUntitled } from "utilities/helpers";
+import styles from "./ActorTypeInput.module.scss";
 
 interface ActorTypeProps {
   actorTypes: ActorType[];
   setActorTypes: (actorTypes: ActorType[]) => void;
-  activeType: string | undefined;
-  setActiveType: (activeType: string | undefined) => void;
+  activeType: number | undefined;
+  setActiveType: (activeType: number | undefined) => void;
 }
 
+/**
+ * Renders a selectable list of all actor types used for the current ruleset
+ * @param actorTypes A list of all actor types for the current ruleset
+ * @param setActorTypes A function to update the list of actor types for this current ruleset
+ * @param activeType The index of the currently active actor type being edited
+ * @param setActiveType A function to update the currently active actor type
+ */
 function ActorTypeList(props: ActorTypeProps) {
   const rows: JSX.Element[] = [];
 
-  for (const actorType of props.actorTypes) {
-    rows.push(
-      <div key={actorType.key}>
-        {actorType.name} ({actorType.key})
-      </div>
-    );
+  /**
+   * Sets the next active type
+   * @param index The index of the actor type to select
+   */
+  function setActiveType(index: number) {
+    if (index === props.activeType) { props.setActiveType(undefined); }
+    else { props.setActiveType(index); }
   }
 
+  /**
+   * Adds a new actor type
+   */
   function add() {
     const actorTypes = [...props.actorTypes];
     const keys = getUniques(actorTypes, "key");
     const untitled = getNextUntitled(keys);
+
     const newActorType: ActorType = {
       name: "Untitled",
       key: untitled,
       description: "",
       actorSheet: { ref: "" },
     };
+
     actorTypes.push(newActorType);
     props.setActorTypes(actorTypes);
+    props.setActiveType(actorTypes.length - 1);
   }
 
+  /**
+   * Removes the currently selected actor type
+   */
   function remove() {
+    if (props.activeType === undefined) { return; }
+    const actorTypes = [...props.actorTypes ];
+    actorTypes.splice(props.activeType, 1);
+    props.setActorTypes(actorTypes);
+    props.setActiveType(undefined);
     return;
+  }
+
+  for (let i = 0; i < props.actorTypes.length; i++) {
+    const actorType = props.actorTypes[i];
+    const className = i === props.activeType ? styles.active : "";
+    rows.push(
+      <div key={actorType.key} className={className} onClick={() => setActiveType(i)}>
+        {actorType.name} ({actorType.key})
+      </div>
+    );
   }
 
   return (
@@ -51,14 +88,83 @@ function ActorTypeList(props: ActorTypeProps) {
   );
 }
 
+/**
+ * Renders a select input for selecting the current type of actor type
+ * @param onChange The function to run when the value of the select changes
+ */
+function ActorTypeSheetSelect(props: { onChange: () => void }) {
+  const router = useRouter();
+  const rulesetRef = router.query.ref || "";
+
+  const options: JSX.Element[] = [];
+  const actorSheetRefs = rulesetRef ? ActorSheetData.search({}) : [];
+
+  for (const actorSheetRef of actorSheetRefs) {
+    const actorSheet = ActorSheetData.get(actorSheetRef);
+    if (!actorSheet || actorSheet.ruleset?.ref !== rulesetRef) { continue; }
+    options.push(<option value={actorSheet.ref}>{actorSheet.name}</option>);
+  }
+
+  return (
+    <>
+      <label htmlFor="actor_type_sheet">Actor Sheet</label>
+      <Select id="actor_type_sheet" name="actorSheet.ref" onChange={props.onChange}>
+        <option>-- None --</option>
+        <>{options}</>
+      </Select>
+    </>
+  );
+}
+
+/**
+ * Renders a form for modifying the values of an actor type
+ * @param actorTypes A list of all actor types for the current ruleset
+ * @param setActorTypes A function to update the list of actor types for this current ruleset
+ * @param activeType The index of the currently active actor type being edited
+ * @param setActiveType A function to update the currently active actor type
+ */
 function ActorTypeForm(props: ActorTypeProps) {
   const style = { flexGrow: 1};
+  if (props.activeType === undefined) { return <div style={style}></div>; }
+
+  const actorType = props.actorTypes[props.activeType];
+
+  /**
+   * Updates the actor type saves in the ruleset
+   * @param updatedActorType The new actor type to save
+   */
+  function onSubmit(updatedActorType: ActorType) {
+    if (props.activeType === undefined) { return; }
+    const actorTypes = [ ...props.actorTypes ];
+    actorTypes[props.activeType] = updatedActorType;
+    props.setActorTypes(actorTypes);
+  }
 
   return (
     <div style={style}>
-      Form
+      <Formik
+        initialValues={actorType}
+        onSubmit={onSubmit}
+      >
+        {(formikProps: FormikProps<ActorType>) => {
+          React.useEffect(() => {
+            formikProps.setValues(actorType);
+          }, [props.activeType]);
+          return (
+            <>
+              <label htmlFor="actor_type_name">Name</label>
+              <Input id="actor_type_name" name="name" type="text" onBlur={formikProps.submitForm}/>
+              <label htmlFor="actor_type_key">Key</label>
+              <Input id="actor_type_key" name="key" type="text" onBlur={formikProps.submitForm}/>
+              <label htmlFor="actor_type_desc">Description</label>
+              <Input id="actor_type_desc" name="description" type="text" onBlur={formikProps.submitForm}/>
+              <ActorTypeSheetSelect onChange={formikProps.submitForm}/>
+            </>
+          );
+        }}
+      </Formik>
     </div>
-  )
+  );
 }
 
 interface ActorTypeInputProps {
@@ -66,8 +172,15 @@ interface ActorTypeInputProps {
   setActorTypes: (actorTypes: ActorType[]) => void;
 }
 
+/**
+ * An input for creating and editing actor types
+ * @param actorTypes The list of all actor types held by the current ruleset
+ * @param setActorTypes A function to update the actor types
+ */
 export function ActorTypeInput(props: ActorTypeInputProps) {
-  const [ activeType, setActiveType ] = React.useState<string | undefined>();
+  const [ activeType, setActiveType ] = React.useState<number | undefined>();
+
+  ActorSheetData.searchIndex("/api/actor-sheets/all");
 
   return (
     <div>

--- a/src/components/reroll/rulesets/Form.tsx
+++ b/src/components/reroll/rulesets/Form.tsx
@@ -4,9 +4,10 @@ import { RulesetData } from "controllers/data/RulesetData";
 import { Form, Formik, FormikProps } from "formik";
 import { useRouter } from "next/router";
 import React from "react";
-import { RulesetDocument } from "types/documents";
+import { ActorType, RulesetDocument } from "types/documents";
 import { CustomFieldInput } from "../forms/customFields/CustomFieldInput";
 import { StaticVariableInput } from "../forms/staticVariables/StaticVariableInput";
+import { ActorTypeInput } from "./ActorTypeInput";
 
 // The initial values of the form
 const INITIAL_VALUES = {
@@ -14,6 +15,7 @@ const INITIAL_VALUES = {
   name: "",
   alias: "",
   actorFields: {},
+  actorTypes: [],
   staticVariables: {},
 };
 
@@ -55,6 +57,12 @@ export function RulesetForm(props: { ruleset?: Partial<RulesetDocument> }) {
         <Form>
           <Input name="name" type="text" label="Name"/>
           <Input name="alias" type="text" label="Alias"/>
+
+          <ActorTypeInput
+            actorTypes={formikProps.values.actorTypes || []}
+            setActorTypes={(actorTypes: ActorType[]) => formikProps.setFieldValue("actorTypes", actorTypes)}
+          />
+          <hr/>
 
           <CustomFieldInput field="actorFields" onChange={formikProps.setFieldValue} values={formikProps.values}/>
           <StaticVariableInput

--- a/src/types/documents/Ruleset.ts
+++ b/src/types/documents/Ruleset.ts
@@ -1,12 +1,22 @@
+import { Ref64 } from "@owl-factory/types";
 import { BaseDocument } from "./BaseDocument";
 import { StaticVariable } from "./subdocument/StaticVariable";
 
+export interface ActorType {
+  name: string; // The name of the actor type, readable to the user ("Player Character, Non-Player Character")
+  key: string; // A key unique to a ruleset identifying which actor type an actor belongs to
+  description: string; // A brief description identifying the purpose of this actor type
+  actorSheet: { ref: Ref64; } // The default, official actor sheet used for this actor type
+}
 
 //TODO make this an interface that adds it's own functionality
 export interface RulesetDocument extends BaseDocument {
   alias: string;
 
-  actorFields: Record<string, unknown>;
+  // ACTORS //
+  actorFields: Record<string, unknown>; // Variable names and types to be used by the actors for this ruleset
+  actorTypes: ActorType[]; // The different kinds of actors supported by this ruleset by default
+
   staticVariables: Record<string, StaticVariable>;
 
   // Indicates whether a ruleset is official or not. Official rulesets are those that are offically supported


### PR DESCRIPTION
Creates an input within a ruleset for creating actor types, which are human-readable types (like Player Character) that can be used for giving players an option when creating a character that automatically assigns an actor sheet. 

Depends on #225 