### PR TITLE
Actor controller expression

### DIFF
--- a/public/dev/mockup.xml
+++ b/public/dev/mockup.xml
@@ -3,7 +3,7 @@
     <Pageable>
       <Page name="Bio">
         <Label>Bio</Label>
-        <Label>Border style: {{sheet.borderStyle}}</Label>
+        <Label>Border style: {$sheet.borderStyle}</Label>
       </Page>
       
       <Page name="Character Sheet" access="edit">
@@ -207,7 +207,7 @@
             <Border borderStyle="simplebox">
               <Inline>
                 <Loop id="currencies_1" name="global.currencies" key="$currency">
-                  <Prefab name="currency" label="{{$currency.name}}" index="{{$currency.index}}"/>
+                  <Prefab name="currency" label="{$currency.name}" index="{$currency.index}"/>
                 </Loop>
               </Inline>
 
@@ -277,15 +277,15 @@
   <Prefabs>
     <NewPrefab name="ability_score" properties="label,score,mod">
       <Background src="/ability_score.svg">
-        <Label>{{properties.label}}</Label>
-        <NumberInput id="{{properties.mod}}_{{properties.uuid}}" name="{{properties.mod}}" calculated="true"/>
-        <NumberInput id="{{properties.score}}_{{properties.uuid}}" name="{{properties.score}}"/>
+        <Label>{$properties.label}</Label>
+        <NumberInput id="{$properties.mod}_{$properties.uuid}" name="{$properties.mod}" calculated="true"/>
+        <NumberInput id="{$properties.score}_{$properties.uuid}" name="{$properties.score}"/>
       </Background>
     </NewPrefab>
 
     <NewPrefab name="skill" properties="">
       <Row>
-        <Column weight="1"><Checkbox name="{{properties.skill.key}}"/></Column>
+        <Column weight="1"><Checkbox name="{$properties.skill.key}"/></Column>
         <Column weight="1">
           <NumberInput id="acrobatics_proficiency_1" name="acrobatics_proficiency" calculated="true" calculateMethod="calc_skill_proficiency"/>
         </Column>
@@ -294,7 +294,7 @@
     </NewPrefab>
   </Prefabs>
 
-  <!-- Variables are sheet-defined values for having consistent values throughout the sheet. They can be accessed with {{sheet.[variableName]}} -->
+  <!-- Variables are sheet-defined values for having consistent values throughout the sheet. They can be accessed with {$sheet.[variableName]} -->
   <Variables>
     <Variable type="string" name="borderStyle" value="default-border-style"/> 
   </Variables>

--- a/src/components/sheets/utilities/expressions/parse.ts
+++ b/src/components/sheets/utilities/expressions/parse.ts
@@ -1,0 +1,159 @@
+import { string } from "yup/lib/locale";
+
+interface ExpressionItem {
+  type: ExpressionType;
+  value?: string;
+}
+
+interface Expression {
+  items: ExpressionItem[];
+}
+
+const EXPRESSION_PART_REGEXES = [
+  /(\$[a-zA-Z0-9][a-zA-Z0-9.]*[a-zA-Z0-9]?)/, // Variable name regex ($foo.bar)
+];
+
+enum ExpressionType {
+  Variable,
+}
+
+/**
+ * Splits a string value up into expression
+ * @param str The string potentially containing one or more expressions
+ * @returns An array of string and Expression objects
+ */
+export function splitExpressionValue(str: string): (string | Expression)[] {
+  const expr: (string | Expression)[] = [];
+  let currentString = str;
+  let i = 0;
+  while(true) {
+    const nextExpressionIndex = getNextExpressionStart(currentString);
+    // There are no further expressions, so escape out
+    if (nextExpressionIndex === -1) {
+      expr.push(currentString);
+      break;
+    }
+    else if (nextExpressionIndex > 0) {
+      expr.push(currentString.substring(0, nextExpressionIndex));
+      currentString = currentString.substring(nextExpressionIndex);
+    }
+    const nextExpressionEnd = getNextExpressionEnd(currentString);
+    const expressionString = currentString.substring(0, nextExpressionEnd);
+    currentString = currentString.substring(nextExpressionEnd);
+
+    expr.push(parseExpression(expressionString));
+
+    // Safety net. If something breaks this prevents an infinite loop
+    i++; if (i>1000) { break; }
+  }
+
+  return expr;
+}
+
+/**
+ * Gets the starting index of the next expression in the given string. Returns -1 if none is found
+ * @param str The string to grab the start position of the next expression
+ */
+function getNextExpressionStart(str: string): number {
+  // Detects expressions of the pattern '{...}'. Backslashes escape the expression start and end
+  const expressionRegex = /(^{|[^\\]{).+?([^\\]})/;
+
+  const index = str.search(expressionRegex);
+  // Not found
+  if (index === -1) { return index; }
+  // The single curly brace regex causes an extra character to be counted at the beginning
+  // If greater than zero is is always the case
+  else if (index > 0) { return index + 1; }
+  // Handles the case of zero where there could be a curly brace at the start or after one character
+  else if (str[0] === '{') { return 0; }
+  return index + 1;
+}
+
+/**
+ * Gets the end index of the expression's end
+ * @param str The string containing at least one full expression
+ */
+function getNextExpressionEnd(str: string): number {
+  // Grabs an expression's end. Uses the pattern '{...}'. Backslashes escape the next curly brace
+  const expressionEndRegex = /[^\\]}/;
+
+  const index = str.search(expressionEndRegex);
+  // Adds 1 since the search includes the preceeding character to ensure that a backslash does not escape the end
+  return index + 1;
+}
+
+/**
+ * Parses a string entirely composed of an expression into an Expression object
+ * @param str The string containing an expression to parse
+ */
+function parseExpression(str: string): Expression {
+  if (str[0] !== '{' || str[str.length - 1] !== '}') {
+    throw `An improper expression was given in the 'parseExpression' function. Expression: '${str}'`;
+  }
+
+  const expr: Expression = { items: [] };
+
+  // Removes the curly braces at the beginning and ends, as well as any padding spaces
+  let currentString = str.substring(1, str.length - 1).trim();
+  let i = 0;
+  while(true) {
+    if (length === 0) { break; }
+    const nextExpressionType = getNextExpressionType(currentString);
+    const nextExpressionEndIndex = getNextExpressionEndIndex(currentString, nextExpressionType);
+    const expressionString = currentString.substring(0, nextExpressionEndIndex);
+    // TODO - check that this doesn't break anything with an out-of-bounds index overflow
+    currentString = currentString.substring(nextExpressionEndIndex);
+
+    const exprItem = convertExpressionItemString(expressionString, nextExpressionType);
+    expr.items.push(exprItem);
+
+    if (++i > 1000) { break; }
+  }
+
+  return expr;
+}
+
+/**
+ * Determines the next expression type within a given string
+ * @param str The string containing one or more expression items
+ */
+function getNextExpressionType(str: string): ExpressionType {
+  const firstChar = str[0];
+  switch (firstChar) {
+    case '$':
+      return ExpressionType.Variable;
+    default:
+      throw "Invalid expression type";
+  }
+}
+
+/**
+ * Determines the index of the first character that is not the first expression
+ * @param str The string containing one or more expression items
+ * @param expressionType The type of the first expression in the string
+ */
+function getNextExpressionEndIndex(str: string, expressionType: ExpressionType) {
+  switch (expressionType) {
+    case ExpressionType.Variable:
+      // Regex finds the next instance of a character not used in a variable or a $ not at the start of the string
+      const variableEndIndex = str.search(/(?<!^)(\$|[^a-zA-Z0-9.])/);
+      if (variableEndIndex === -1) { return str.length; }
+      return variableEndIndex;
+  }
+}
+
+/**
+ * Converts a string and expression type into an expression item for easier parsing on render
+ * @param str The string containing a single expression
+ * @param expressionType The type of expression being converted
+ */
+function convertExpressionItemString(str: string, expressionType: ExpressionType): ExpressionItem {
+  switch (expressionType) {
+    case ExpressionType.Variable:
+      const variableExpressionItem: ExpressionItem = {
+        type: expressionType,
+        value: str,
+      };
+      return variableExpressionItem;
+  }
+}

--- a/src/controllers/actor/ActorController.ts
+++ b/src/controllers/actor/ActorController.ts
@@ -1,8 +1,9 @@
+import { Expression, ExpressionType } from "components/sheets/utilities/expressions/parse";
 import { action, makeObservable, observable } from "mobx";
 import { RulesetDocument } from "types/documents";
 import { ActorSheetDocument } from "types/documents/ActorSheet";
 import { PageElementDescriptor } from "types/sheetElementDescriptors";
-import { GenericSheetElementDescriptor, SheetVariableTuple } from "types/sheetElementDescriptors/generic";
+import { GenericSheetElementDescriptor } from "types/sheetElementDescriptors/generic";
 import { SheetController } from "./ActorSheetController";
 import { ActorSubController } from "./ActorSubController";
 import { RuleVariableGroup, RulesetController } from "./RulesetController";
@@ -201,7 +202,7 @@ class $ActorController {
     for (const field of fields) {
       if (!(field in element)) { continue; }
       const value = element[field as (keyof T)];
-      parsedVariables[field] = ActorController.renderVariable(id, value);
+      parsedVariables[field] = ActorController.renderVariable(id, value as unknown as (string | Expression)[]);
     }
 
     return parsedVariables;
@@ -209,20 +210,43 @@ class $ActorController {
 
   /**
    * Renders out a single variable
-   * @param id The ID of the render
-   * @param value The object containing the information required to render
+   * @param renderID The ID of the render
+   * @param exprs An array containing an expression or string(s) to render out
    * @returns A single string containing the rendered value
    */
-  public renderVariable(id: string, value: unknown): string {
-    if (typeof value === "string") return value;
-    else if (!Array.isArray(value)) { return value as string; } // Should never happen
+  public renderVariable(renderID: string, exprs: (string | Expression)[]): string {
+    // Base case where we ensure that we have the correct type
+    if (!Array.isArray(exprs) || exprs.length === 0) { return ""; }
+    let renderedResult = "";
+    for (const expr of exprs) {
+      // Not an expression, just a string
+      if (typeof expr === "string") {
+        renderedResult += expr;
+        continue;
+      }
 
-    let output = '';
-    for (const chunk of value) {
-      if (Array.isArray(chunk)) { output += this.convertVariableToData(id, chunk); }
-      else { output += chunk; }
+      renderedResult += this.renderExpression(renderID, expr);
     }
-    return output;
+
+    return renderedResult;
+  }
+
+  /**
+   * Renders an expression into a string
+   * @param renderID The ID of the render to use for determining the expression values
+   * @param expr The expression to render out
+   */
+  public renderExpression(renderID: string, expr: Expression) {
+    let renderedResult = "";
+    for (const item of expr.items) {
+      switch (item.type) {
+        case ExpressionType.Variable:
+          renderedResult += this.convertVariableToData(renderID, item.value || "");
+          break;
+      }
+
+    }
+    return renderedResult;
   }
 
   /**
@@ -231,17 +255,33 @@ class $ActorController {
    * @param chunk The variable tuple to decode
    * @returns The value of the decoded variable
    */
-  public convertVariableToData(id: string, chunk: SheetVariableTuple) {
+  public convertVariableToData(id: string, variable: string) {
+    if (!variable) { return ""; }
+
+    const firstPeriodIndex = variable.search(/\./);
+
+    // Grabs the first portion of the variable for determining where to look for the value
+    let firstAddress, remainderAddress;
+    if (firstPeriodIndex > 0) {
+      firstAddress = variable.substring(0, firstPeriodIndex);
+      remainderAddress = variable.substring(firstPeriodIndex + 1);
+    } else {
+      firstAddress = variable;
+      remainderAddress = variable;
+    }
+
     const { rulesetRef, sheetRef } = this.$renders[id];
-    switch (chunk[0]) {
+    switch (firstAddress) {
       case "character":
-        const characterValue = this.getActorField(id, chunk[1]);
+        const characterValue = this.getActorField(id, remainderAddress);
         return characterValue;
       case "rules":
-        const ruleValue = this.rulesetController.getRulesetVariable(rulesetRef, RuleVariableGroup.STATIC, chunk[1]);
+        const ruleValue = this.rulesetController.getRulesetVariable(
+          rulesetRef, RuleVariableGroup.STATIC, remainderAddress
+        );
         return ruleValue;
       case "sheet":
-        const sheetValue = this.sheetController.getVariable(sheetRef, chunk[1]);
+        const sheetValue = this.sheetController.getVariable(sheetRef, remainderAddress);
         return sheetValue;
     }
 

--- a/src/controllers/actor/ActorSheetController.ts
+++ b/src/controllers/actor/ActorSheetController.ts
@@ -1,3 +1,4 @@
+import { splitExpressionValue } from "components/sheets/utilities/expressions/parse";
 import { parseXML } from "controllers/layout/parser";
 import { action, makeObservable, observable } from "mobx";
 import { PageElementType, elementNameToPageElementType } from "types/enums/pageElementType";
@@ -18,7 +19,6 @@ import {
   TextAreaElementDescriptor,
   TextInputElementDescriptor,
 } from "types/sheetElementDescriptors";
-import { ParsedSheetVariable, SheetVariableTuple } from "types/sheetElementDescriptors/generic";
 import { PrefabElementDescriptor } from "types/sheetElementDescriptors/prefab";
 
 export interface SheetTabElementDescriptor {
@@ -364,8 +364,8 @@ export class SheetController<T> {
   protected parseLabelElement(labelElement: Element) {
     const elementDetails: LabelElementDescriptor = {
       element: PageElementType.Label,
-      for: parseVariableString(labelElement.getAttribute("for") || ""),
-      text: parseVariableString(labelElement.textContent || "Unknown"),
+      for: splitExpressionValue(labelElement.getAttribute("for") || ""),
+      text: splitExpressionValue(labelElement.textContent || "Unknown"),
     };
 
     return elementDetails;
@@ -379,8 +379,8 @@ export class SheetController<T> {
   protected parseCheckboxElement(checkboxElement: Element) {
     const elementDetails: NumberInputElementDescriptor = {
       element: PageElementType.Checkbox,
-      id: parseVariableString(checkboxElement.getAttribute("id") || ""),
-      name: parseVariableString(checkboxElement.getAttribute("name") || "missing_name"),
+      id: splitExpressionValue(checkboxElement.getAttribute("id") || ""),
+      name: splitExpressionValue(checkboxElement.getAttribute("name") || "missing_name"),
     };
 
     return elementDetails;
@@ -394,8 +394,8 @@ export class SheetController<T> {
   protected parseNumberInputElement(numberInputElement: Element) {
     const elementDetails: NumberInputElementDescriptor = {
       element: PageElementType.NumberInput,
-      id: parseVariableString(numberInputElement.getAttribute("id") || ""),
-      name: parseVariableString(numberInputElement.getAttribute("name") || "missing_name"),
+      id: splitExpressionValue(numberInputElement.getAttribute("id") || ""),
+      name: splitExpressionValue(numberInputElement.getAttribute("name") || "missing_name"),
     };
 
     return elementDetails;
@@ -409,8 +409,8 @@ export class SheetController<T> {
   protected parseTextInputElement(textInputElement: Element) {
     const elementDetails: TextInputElementDescriptor = {
       element: PageElementType.TextInput,
-      id: parseVariableString(textInputElement.getAttribute("id") || ""),
-      name: parseVariableString(textInputElement.getAttribute("name") || "missing_name"),
+      id: splitExpressionValue(textInputElement.getAttribute("id") || ""),
+      name: splitExpressionValue(textInputElement.getAttribute("name") || "missing_name"),
     };
 
     return elementDetails;
@@ -424,8 +424,8 @@ export class SheetController<T> {
   protected parseTextAreaElement(textAreaElement: Element) {
     const elementDetails: TextAreaElementDescriptor = {
       element: PageElementType.TextArea,
-      id: parseVariableString(textAreaElement.getAttribute("id") || ""),
-      name: parseVariableString(textAreaElement.getAttribute("name") || ""),
+      id: splitExpressionValue(textAreaElement.getAttribute("id") || ""),
+      name: splitExpressionValue(textAreaElement.getAttribute("name") || ""),
     };
 
     return elementDetails;
@@ -439,8 +439,8 @@ export class SheetController<T> {
   protected parseSelectElement(selectElement: Element) {
     const elementDetails: TextAreaElementDescriptor = {
       element: PageElementType.Select,
-      id: parseVariableString(selectElement.getAttribute("id") || ""),
-      name: parseVariableString(selectElement.getAttribute("name") || ""),
+      id: splitExpressionValue(selectElement.getAttribute("id") || ""),
+      name: splitExpressionValue(selectElement.getAttribute("name") || ""),
     };
 
     return elementDetails;
@@ -475,9 +475,9 @@ export class SheetController<T> {
   protected parseRadioElement(radioElement: Element) {
     const elementDetails: RadioElementDescriptor = {
       element: PageElementType.Radio,
-      id: parseVariableString(radioElement.getAttribute("id") || "undefined"),
-      name: parseVariableString(radioElement.getAttribute("name") || "undefined"),
-      value: parseVariableString(radioElement.getAttribute("value") || "1"),
+      id: splitExpressionValue(radioElement.getAttribute("id") || "undefined"),
+      name: splitExpressionValue(radioElement.getAttribute("name") || "undefined"),
+      value: splitExpressionValue(radioElement.getAttribute("value") || "1"),
     };
 
     return elementDetails;
@@ -491,10 +491,10 @@ export class SheetController<T> {
    protected parseRadioButtonElement(radioButtonElement: Element) {
     const elementDetails: RadioButtonElementDescriptor = {
       element: PageElementType.RadioButton,
-      id: parseVariableString(radioButtonElement.getAttribute("id") || "undefined"),
-      name: parseVariableString(radioButtonElement.getAttribute("name") || "undefined"),
-      value: parseVariableString(radioButtonElement.getAttribute("value") || "1"),
-      label: parseVariableString(radioButtonElement.textContent || "Unknown"),
+      id: splitExpressionValue(radioButtonElement.getAttribute("id") || "undefined"),
+      name: splitExpressionValue(radioButtonElement.getAttribute("name") || "undefined"),
+      value: splitExpressionValue(radioButtonElement.getAttribute("value") || "1"),
+      label: splitExpressionValue(radioButtonElement.textContent || "Unknown"),
     };
 
     return elementDetails;
@@ -545,90 +545,3 @@ function getBaseElements(sheet: Element) {
   }
   return { layout, prefabs, variables };
 }
-
-/**
- * Parses a string into a collection of static values and pesudo-tuples to prepare for decoding when on display
- * @param value The string to parse
- * @returns An array of strings or pseudo-tuples containing either static values or variables, respectively
- */
-function parseVariableString(value: string | null): ParsedSheetVariable {
-  const chunks: ParsedSheetVariable = [];
-  if (value === null || value === undefined) { return [""]; }
-  while(true) {
-    const variableStart = value.search(/{{/);
-    if (variableStart === -1) {
-      chunks.push(value);
-      break;
-    }
-    const variableEnd = value.search(/}}/);
-    // Case: variable start, but no end
-    if (variableEnd === -1) {
-      chunks.push(value);
-      console.error("An improper variable format was used");
-      break;
-    }
-
-    if (variableStart > 0) {
-      const staticString = value.substring(0, variableStart);
-      // value = value.substring(variableStart);
-      chunks.push(staticString);
-    }
-
-    const variableChunk = value.substring(variableStart, variableEnd + 2);
-    const decodedVariable = encodeVariableIntoTuple(variableChunk);
-
-    chunks.push(decodedVariable);
-    value = value.substring(variableEnd + 2);
-  }
-
-  return chunks;
-}
-
-/**
- * Checks if the given value is a viable variable
- * @param potentialVariable The potential variable
- * @returns True if is is a viable variable, false otherwise
- */
-export function isVariable(potentialVariable: string | string[]): boolean {
-  if (!Array.isArray(potentialVariable)) { return false; }
-  return true;
-}
-
-/**
- * Decodes a variable into a pseudo-tuple for easier access when rendered into a sheet
- * @param str The variable string
- * @returns A pseudo-tuple. Slot 0 is the variable group, slot 1 is the variable name.
- * Invalid variables are returned as a string
- */
-function encodeVariableIntoTuple(str: string): (string | SheetVariableTuple) {
-  const fullVariable = str.substring(2, str.length - 2);
-  const periodIndex = fullVariable.search(/\./);
-  const group = fullVariable.substring(0, periodIndex).toLowerCase(); // Put into lowercase for ease of access
-  const variableName = fullVariable.substring(periodIndex + 1);
-
-  if (!isValidVariableGroup(group)) {
-    return fullVariable; // Full variable is a 'failed variable'
-  }
-  // TODO - error checking
-
-  return [group, variableName];
-}
-
-/**
- * Checks if a given variable group is valid.
- * @param group The group to check for validity
- * @returns True if the group is valid, false otherwise
- */
-function isValidVariableGroup(group: string) {
-  switch (group) {
-    case "character":
-    case "rules":
-    case "sheet":
-      return true;
-    default:
-      return false;
-  }
-}
-
-
-

--- a/src/types/sheetElementDescriptors/generic.ts
+++ b/src/types/sheetElementDescriptors/generic.ts
@@ -1,7 +1,7 @@
+import { Expression } from "components/sheets/utilities/expressions/parse";
 import { PageElementType } from "types/enums/pageElementType";
 
-export type SheetVariableTuple = string[];
-export type ParsedSheetVariable = (string | SheetVariableTuple)[];
+export type ParsedSheetVariable = (string | Expression)[];
 
 /**
  * Describes a generic sheet element


### PR DESCRIPTION
Converts the actor sheet variables, previously represented by {{variable.name}}, into expressions. Expressions are marked by curly braces and will eventually allow for functionality to be implemented by sheet makers. Currently, only variables are supported. Variables are now represented by a leading $. 

Depends on #236 