### PR TITLE
Actor sheet table elements

### DIFF
--- a/public/dev/mockup.xml
+++ b/public/dev/mockup.xml
@@ -8,8 +8,8 @@
         </Loop>
 
         <Label>A List of Greetings:</Label>
-        <Loop key="greeting" list="{$rules.greetings}">
-          <Label>Greeting: {$greeting}</Label>
+        <Loop key="language" list="{$rules.languageTypes}">
+          <Label>Language Types: {$language}</Label>
         </Loop>
 
        <Label>A List of Actions:</Label>
@@ -84,13 +84,13 @@
           <Column weight="1">
             <Row>
               <Column weight="1">
-                <Prefab name="ability_score" label="Strength" score="strength" mod="str_mod"/>
-                <Prefab name="ability_score" label="Dexterity" score="dexterity" mod="dex_mod"/>
-                <Prefab name="ability_score" label="Constitution" score="constitution" mod="con_mod"/>
-                <Prefab name="ability_score" label="Intelligence" score="intelligence" mod="int_mod"/>
-                <Prefab name="ability_score" label="Wisdom" score="wisdom" mod="wis_mod"/>
-                <Prefab name="ability_score" label="Charisma" score="charisma" mod="cha_mod"/>
+                <Loop list="{$rules.ability_scores}" key="ability_score">
+                  <Label>{$ability_score.label}</Label>
+                  <NumberInput name="{$ability_score.mod}" /> <!-- The modifier-->
+                  <NumberInput name="{$ability_score.score}" /> <!-- The total ability score -->
+                </Loop>
               </Column>
+
               <Column weight="2">
                 <Background src="inspiration">
                   <Inline>
@@ -107,15 +107,72 @@
                 </Background>
 
                 <Border borderStyle="simpleBorder">
-                  <Prefab name="skill" label="Acrobatics"/>
-                  <Prefab name="skill" label="Acrobatics"/>
-                  <Prefab name="skill" label="Acrobatics"/>
-                  <Prefab name="skill" label="Acrobatics"/>
-                  <Prefab name="skill" label="Acrobatics"/>
+                  <Loop list="{$rules.savingThrows}" index="savingThrowIndex" key="savingThrow">
+                    <Inline>
+                      <Checkbox name="{$savingThrow.proficiency}"/>
+                      <NumberInput name="{$savingThrow.mod}"/>
+                      <Label>{$savingThrow.name}</Label>
+                    </Inline>
+                  </Loop>
+                </Border>
+
+                <Border borderStyle="simpleBorder">
+                  <Loop list="{$rules.abilities}" key="ability">
+                    <Checkbox name="{$ability.proficiency}"/>
+                    <NumberInput name="{$ability.mod}"/>
+                    <Label>
+                      {$ability.ability} ({$ability.mod_name})
+                    </Label>
+                  </Loop>
                   <Label>Skills</Label>
                 </Border>
               </Column>
             </Row>
+
+            <Border>
+              <Inline>
+                <Label>1{$character.wisdom_mod}</Label>
+                <Label>Passive Wisdom (Perception)</Label>
+              </Inline>
+            </Border>
+
+            <Border>
+              <Table>
+                <TableRow>
+                  <TableCell><Label>Tool</Label></TableCell>
+                  <TableCell><Label>Pro</Label></TableCell>
+                  <TableCell><Label>Attribute</Label></TableCell>
+                </TableRow>
+                <Loop list="{$content.tools}" key="tool" index="toolIndex">
+                  <TableRow>
+                    <TableCell><TextInput id="tool_name_{$index}" name="tool.name"/></TableCell>
+                    <TableCell><NumberInput id="tool_proficiency_{$index}" name="tool.proficiency"/></TableCell>
+                    <TableCell><TextInput id="tool_attribute_{$index}" name="tool.attribute"/></TableCell>
+                    <TableCell><Button action="deleteContent" index="{$toolIndex}" contentGroup="tools">-</Button></TableCell>
+                  </TableRow>
+                </Loop>
+              </Table>
+              <Button action="createContent" contentGroup="tools">+</Button>
+              <Label>Tool Proficiencies &amp; Custom Skills</Label> 
+            </Border>
+
+            <Border>
+              <Table>
+                <TableRow>
+                  <TableCell><Label>Type</Label></TableCell>
+                  <TableCell><Label>Attribute</Label></TableCell>
+                </TableRow>
+                <Loop list="{$content.languages}" key="language" index="languageIndex">
+                  <TableRow>
+                    <TableCell><TextInput id="language_name_{$index}" name="language.name"/></TableCell>
+                    <TableCell><TextInput id="language_proficiency_{$index}" name="language.proficiency"/></TableCell>
+                    <TableCell><Button action="deleteContent" index="{$languageIndex}" contentGroup="languages">-</Button></TableCell>
+                  </TableRow>
+                </Loop>
+              </Table>
+              <Button action="createContent" contentGroup="languages">+</Button>
+              <Label>Other Proficiencies &amp; Languages</Label> 
+            </Border>
           </Column>
 
           <!-- HP, Attacks, Equipment -->

--- a/src/nodes/actor-sheets/components/SheetElement.tsx
+++ b/src/nodes/actor-sheets/components/SheetElement.tsx
@@ -15,6 +15,9 @@ import {
   SelectDescriptor,
   TextAreaDescriptor,
   TextInputDescriptor,
+  TableDescriptor,
+  TableCellDescriptor,
+  TableRowDescriptor,
 } from "nodes/actor-sheets/types/elements";
 import { GenericSheetElementDescriptor } from "nodes/actor-sheets/types/elements/generic";
 import {
@@ -40,6 +43,9 @@ import { ButtonDescriptor } from "../types/elements/button";
 import { SheetButton } from "./elements/Button";
 import { SheetElementType } from "../enums/sheetElementType";
 import { LoopDescriptor } from "../types/elements/loop";
+import { SheetTable } from "./elements/Table";
+import { SheetTableCell } from "./elements/TableCell";
+import { SheetTableRow } from "./elements/TableRow";
 
 /**
  * Determines which sheet element to render based on the descriptor element type given
@@ -72,6 +78,12 @@ export function SheetElement(props: SheetElementProps<GenericSheetElementDescrip
      return <SheetRadioButton {...props} element={props.element as RadioButtonDescriptor}/>;
     case SheetElementType.NumberInput:
       return <SheetNumberInput {...props} element={props.element as NumberInputDescriptor}/>;
+    case SheetElementType.Table:
+      return <SheetTable {...props} element={props.element as TableDescriptor}/>;
+    case SheetElementType.TableCell:
+      return <SheetTableCell {...props} element={props.element as TableCellDescriptor}/>;
+    case SheetElementType.TableRow:
+      return <SheetTableRow {...props} element={props.element as TableRowDescriptor}/>;
     case SheetElementType.TextInput:
       return <SheetTextInput {...props} element={props.element as TextInputDescriptor}/>;
     case SheetElementType.TextArea:

--- a/src/nodes/actor-sheets/components/elements/Loop.tsx
+++ b/src/nodes/actor-sheets/components/elements/Loop.tsx
@@ -23,9 +23,9 @@ function SheetLoopItem(props: SheetElementProps<LoopDescriptor>) {
     );
   }
   return (
-    <div>
+    <>
       {elements}
-    </div>
+    </>
   );
 }
 
@@ -71,8 +71,8 @@ export const SheetLoop = observer((props: SheetElementProps<LoopDescriptor>) => 
   }
 
   return (
-    <div>
+    <>
       {loopedElements}
-    </div>
+    </>
   );
 });

--- a/src/nodes/actor-sheets/components/elements/Table.tsx
+++ b/src/nodes/actor-sheets/components/elements/Table.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { TableDescriptor } from "nodes/actor-sheets/types/elements";
+import { SheetElement } from "../SheetElement";
+import { SheetElementProps } from "../../types";
+
+/**
+ * Renders an table element
+ * @param element The table element description
+ */
+export function SheetTable(props: SheetElementProps<TableDescriptor>) {
+  const childElements = props.element.children || [];
+  const elements: JSX.Element[] = [];
+  for (const childElement of childElements) {
+    elements.push(<SheetElement key={props.properties.$prefix + childElement.$key} {...props} element={childElement}/>);
+  }
+  return (
+    <table >
+      <tbody>
+        {elements}
+      </tbody>
+    </table>
+  );
+}

--- a/src/nodes/actor-sheets/components/elements/TableCell.tsx
+++ b/src/nodes/actor-sheets/components/elements/TableCell.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { TableCellDescriptor } from "nodes/actor-sheets/types/elements";
+import { SheetElement } from "../SheetElement";
+import { SheetElementProps } from "../../types";
+
+/**
+ * Renders an table cell element
+ * @param element The table cell element description
+ */
+export function SheetTableCell(props: SheetElementProps<TableCellDescriptor>) {
+  const childElements = props.element.children || [];
+  const elements: JSX.Element[] = [];
+  for (const childElement of childElements) {
+    elements.push(<SheetElement key={props.properties.$prefix + childElement.$key} {...props} element={childElement}/>);
+  }
+  return (
+    <td >
+      {elements}
+    </td>
+  );
+}

--- a/src/nodes/actor-sheets/components/elements/TableRow.tsx
+++ b/src/nodes/actor-sheets/components/elements/TableRow.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { TableRowDescriptor } from "nodes/actor-sheets/types/elements";
+import { SheetElement } from "../SheetElement";
+import { SheetElementProps } from "../../types";
+
+/**
+ * Renders an table row element
+ * @param element The table row element description
+ */
+export function SheetTableRow(props: SheetElementProps<TableRowDescriptor>) {
+  const childElements = props.element.children || [];
+  const elements: JSX.Element[] = [];
+  for (const childElement of childElements) {
+    elements.push(<SheetElement key={props.properties.$prefix + childElement.$key} {...props} element={childElement}/>);
+  }
+  return (
+    <tr >
+      {elements}
+    </tr>
+  );
+}

--- a/src/nodes/actor-sheets/controllers/ActorController.ts
+++ b/src/nodes/actor-sheets/controllers/ActorController.ts
@@ -155,7 +155,7 @@ class $ActorController {
     // Catches all failure cases where some piece of data is missing
     if (contentType === "" || index === undefined || index < 0 || name === "") { return ""; }
 
-    return this.actorController.getContentField(actorRef, contentType, index, name);
+    return this.actorController.getContentField(actorRef, contentType, index, name) || "";
   }
 
   /**

--- a/src/nodes/actor-sheets/enums/sheetElementType.ts
+++ b/src/nodes/actor-sheets/enums/sheetElementType.ts
@@ -17,6 +17,9 @@ export enum SheetElementType {
   Background, // Places an image or svg behind the given children
   Border, // Places a border around the children
   Inline, // Indicates that the children should be rendered inline but without specific spacing
+  Table, // Indicates that the children are part of a table
+  TableRow, // Contains a single row of table cells
+  TableCell, // A single cell within a table
 
   // Styling Elements without children
   Icon, // An Icon selected from a list of icons
@@ -75,6 +78,12 @@ export function elementNameToPageElementType(tagName: string) {
       return SheetElementType.Radio;
     case "numberinput":
       return SheetElementType.NumberInput;
+    case "table":
+      return SheetElementType.Table;
+    case "tablecell":
+      return SheetElementType.TableCell;
+    case "tablerow":
+      return SheetElementType.TableRow;
     case "textinput":
       return SheetElementType.TextInput;
     case "textarea":

--- a/src/nodes/actor-sheets/types/elements/index.ts
+++ b/src/nodes/actor-sheets/types/elements/index.ts
@@ -15,5 +15,8 @@ export * from "./radioButton";
 export * from "./radio";
 export * from "./row";
 export * from "./select";
+export * from "./table";
+export * from "./tableCell";
+export * from "./tableRow";
 export * from "./textArea";
 export * from "./textInput";

--- a/src/nodes/actor-sheets/types/elements/table.ts
+++ b/src/nodes/actor-sheets/types/elements/table.ts
@@ -1,0 +1,8 @@
+import { GenericSheetElementDescriptor } from "./generic";
+
+/**
+ * Describes a sheet table element
+ */
+export interface TableDescriptor extends GenericSheetElementDescriptor {
+  children: GenericSheetElementDescriptor[];
+}

--- a/src/nodes/actor-sheets/types/elements/tableCell.ts
+++ b/src/nodes/actor-sheets/types/elements/tableCell.ts
@@ -1,0 +1,8 @@
+import { GenericSheetElementDescriptor } from "./generic";
+
+/**
+ * Describes a sheet table cell element
+ */
+export interface TableCellDescriptor extends GenericSheetElementDescriptor {
+  children: GenericSheetElementDescriptor[];
+}

--- a/src/nodes/actor-sheets/types/elements/tableRow.ts
+++ b/src/nodes/actor-sheets/types/elements/tableRow.ts
@@ -1,0 +1,8 @@
+import { GenericSheetElementDescriptor } from "./generic";
+
+/**
+ * Describes a sheet table row element
+ */
+export interface TableRowDescriptor extends GenericSheetElementDescriptor {
+  children: GenericSheetElementDescriptor[];
+}

--- a/src/nodes/actor-sheets/utilities/expressions/parse.ts
+++ b/src/nodes/actor-sheets/utilities/expressions/parse.ts
@@ -2,7 +2,7 @@ import { ExpressionType } from "nodes/actor-sheets/enums/expressionType";
 import { Expression, ExpressionItem, ParsedExpressionString } from "nodes/actor-sheets/types/expressions";
 
 const EXPRESSION_PART_REGEXES = [
-  /(\$[a-zA-Z0-9][a-zA-Z0-9.]*[a-zA-Z0-9]?)/, // Variable name regex ($foo.bar)
+  /(\$[a-zA-Z0-9-_][a-zA-Z0-9.]*[a-zA-Z0-9-_]?)/, // Variable name regex ($foo.bar)
 ];
 
 /**
@@ -128,7 +128,7 @@ function getNextExpressionEndIndex(str: string, expressionType: ExpressionType):
   switch (expressionType) {
     case ExpressionType.Variable:
       // Regex finds the next instance of a character not used in a variable or a $ not at the start of the string
-      const variableEndIndex = str.search(/(?<!^)(\$|[^a-zA-Z0-9.])/);
+      const variableEndIndex = str.search(/(?<!^)(\$|[^a-zA-Z0-9.-_])/);
       if (variableEndIndex === -1) { return str.length; }
       return variableEndIndex;
   }

--- a/src/nodes/actor-sheets/utilities/parse/table-cell.ts
+++ b/src/nodes/actor-sheets/utilities/parse/table-cell.ts
@@ -1,0 +1,21 @@
+import { SheetElementType } from "nodes/actor-sheets/enums/sheetElementType";
+import { SheetState } from "nodes/actor-sheets/types";
+import { TableCellDescriptor } from "nodes/actor-sheets/types/elements";
+import { parseChildrenElements } from "./children";
+
+/**
+ * Converts a table cell element into a table cell element descriptor
+ * @param element The raw <TableCell> element to convert
+ * @returns A table cell element descriptor
+ */
+export function parseTableCellElement(element: Element, state: SheetState) {
+  const elementDetails: TableCellDescriptor = {
+    $key: state.key,
+    element: SheetElementType.TableCell,
+    children: [],
+  };
+
+  elementDetails.children = parseChildrenElements(element.children, state);
+
+  return elementDetails;
+}

--- a/src/nodes/actor-sheets/utilities/parse/table-row.ts
+++ b/src/nodes/actor-sheets/utilities/parse/table-row.ts
@@ -1,0 +1,21 @@
+import { SheetElementType } from "nodes/actor-sheets/enums/sheetElementType";
+import { SheetState } from "nodes/actor-sheets/types";
+import { TableRowDescriptor } from "nodes/actor-sheets/types/elements";
+import { parseChildrenElements } from "./children";
+
+/**
+ * Converts a table row element into a table row element descriptor
+ * @param element The raw <TableRow> element to convert
+ * @returns A table row element descriptor
+ */
+export function parseTableRowElement(element: Element, state: SheetState) {
+  const elementDetails: TableRowDescriptor = {
+    $key: state.key,
+    element: SheetElementType.TableRow,
+    children: [],
+  };
+
+  elementDetails.children = parseChildrenElements(element.children, state);
+
+  return elementDetails;
+}

--- a/src/nodes/actor-sheets/utilities/parse/table.ts
+++ b/src/nodes/actor-sheets/utilities/parse/table.ts
@@ -1,0 +1,21 @@
+import { SheetElementType } from "nodes/actor-sheets/enums/sheetElementType";
+import { SheetState } from "nodes/actor-sheets/types";
+import { TableDescriptor } from "nodes/actor-sheets/types/elements";
+import { parseChildrenElements } from "./children";
+
+/**
+ * Converts a table element into a table element descriptor
+ * @param element The raw <Table> element to convert
+ * @returns A table element descriptor
+ */
+export function parseTableElement(element: Element, state: SheetState) {
+  const elementDetails: TableDescriptor = {
+    $key: state.key,
+    element: SheetElementType.Table,
+    children: [],
+  };
+
+  elementDetails.children = parseChildrenElements(element.children, state);
+
+  return elementDetails;
+}

--- a/src/nodes/actor-sheets/utilities/parse/unknown.ts
+++ b/src/nodes/actor-sheets/utilities/parse/unknown.ts
@@ -17,6 +17,9 @@ import { parsePrefabElement } from "./prefab";
 import { parseRadioElement } from "./radio";
 import { parseRowElement } from "./row";
 import { parseSelectElement } from "./select";
+import { parseTableElement } from "./table";
+import { parseTableCellElement } from "./table-cell";
+import { parseTableRowElement } from "./table-row";
 import { parseTextAreaElement } from "./text-area";
 import { parseTextInputElement } from "./text-input";
 
@@ -42,6 +45,14 @@ export function parseUnknownElement(element: Element, state: SheetState) {
       return parseBorderElement(element, state);
     case SheetElementType.Inline:
       return parseInlineElement(element, state);
+
+    case SheetElementType.Table:
+      return parseTableElement(element, state);
+    case SheetElementType.TableCell:
+      return parseTableCellElement(element, state);
+    case SheetElementType.TableRow:
+      return parseTableRowElement(element, state);
+
 
 
     case SheetElementType.Icon:


### PR DESCRIPTION
Changes:
- Adds \<Table\>, \<TableRow\>, and \<TableCell\> elements to the actor sheet
- Fixes an issue where actor sheet variables using '-' and '_' were not read correctly
- Fixes an issue where an undefined content value (such as from creating a new content item) in an actor sheet caused an error

Depends on #247