### PR TITLE
Actor sheet children element

### DIFF
--- a/src/components/reroll/actorSheets/Form.tsx
+++ b/src/components/reroll/actorSheets/Form.tsx
@@ -70,7 +70,11 @@ export const ActorSheetForm = observer((props: ActorSheetFormProps) => {
         }
       </Formik>
       <hr/>
-      <ActorSheet id={props.renderID}/>
+      {() => {
+        // Try/Catch block prevents issues within the actor sheet preventing updating of the XML
+        try { return <ActorSheet id={props.renderID}/>; }
+        catch (e) { return <></>; }
+      }}
     </div>
   );
 });

--- a/src/nodes/actor-sheets/components/ActorSheet.tsx
+++ b/src/nodes/actor-sheets/components/ActorSheet.tsx
@@ -30,7 +30,8 @@ export const ActorSheet = observer((props: ActorSheetProps) => {
     sheetElements.push(
       <SheetElement
         key={props.id + childElement.$key}
-        id={props.id}
+        $key={props.id + childElement.$key}
+        renderID={props.id}
         element={childElement}
         properties={properties}
       />

--- a/src/nodes/actor-sheets/components/elements/Background.tsx
+++ b/src/nodes/actor-sheets/components/elements/Background.tsx
@@ -1,21 +1,16 @@
 import React from "react";
 import { BackgroundDescriptor } from "nodes/actor-sheets/types/elements";
-import { SheetElement } from "../SheetElement";
 import { SheetElementProps } from "../../types";
+import { SheetChildren } from "./Children";
 
 /**
  * Renders an image of the background
  * @param element The SheetBackground element description
  */
 export function SheetBackground(props: SheetElementProps<BackgroundDescriptor>) {
-  const childElements = props.element.children || [];
-  const elements: JSX.Element[] = [];
-  for (const childElement of childElements) {
-    elements.push(<SheetElement key={props.properties.$prefix + childElement.$key} {...props} element={childElement}/>);
-  }
   return (
     <div>
-      {elements}
+      <SheetChildren {...props}/>
     </div>
   );
 }

--- a/src/nodes/actor-sheets/components/elements/Border.tsx
+++ b/src/nodes/actor-sheets/components/elements/Border.tsx
@@ -1,22 +1,17 @@
 import React from "react";
 import { BorderDescriptor } from "nodes/actor-sheets/types/elements/border";
-import { SheetElement } from "../SheetElement";
 import style from "../../styles/Border.module.scss";
 import { SheetElementProps } from "../../types";
+import { SheetChildren } from "./Children";
 
 /**
  * Renders a border around given children
  * @param element The SheetBorder element description
  */
 export function SheetBorder(props: SheetElementProps<BorderDescriptor>) {
-  const childElements = props.element.children || [];
-  const elements: JSX.Element[] = [];
-  for (const childElement of childElements) {
-    elements.push(<SheetElement key={props.properties.$prefix + childElement.$key} {...props} element={childElement}/>);
-  }
   return (
     <div className={`${style.border}`}>
-      {elements}
+      <SheetChildren {...props}/>
     </div>
   );
 }

--- a/src/nodes/actor-sheets/components/elements/Button.tsx
+++ b/src/nodes/actor-sheets/components/elements/Button.tsx
@@ -13,14 +13,14 @@ const VARIABLE_FIELDS = ["text", "alert", "contentGroup", "index", "target"];
  */
 export const SheetButton = observer((props: SheetElementProps<ButtonDescriptor>) => {
   const elementVariables = ActorController.renderVariables<ButtonDescriptor>(
-    props.id,
+    props.renderID,
     props.element,
     VARIABLE_FIELDS,
     props.properties,
   );
 
   return (
-    <button onClick={() => onClick(props.element.action, props.id, elementVariables)}>
+    <button onClick={() => onClick(props.element.action, props.renderID, elementVariables)}>
       {elementVariables.text}
     </button>
   );

--- a/src/nodes/actor-sheets/components/elements/Checkbox.tsx
+++ b/src/nodes/actor-sheets/components/elements/Checkbox.tsx
@@ -14,21 +14,21 @@ export const SheetCheckbox = observer((props: SheetElementProps<CheckboxDescript
   const ref = React.createRef<HTMLInputElement>();
 
   const element = ActorController.renderVariables<CheckboxDescriptor>(
-    props.id,
+    props.renderID,
     props.element,
     VARIABLE_FIELDS,
     props.properties,
   );
   const key = generateCheckboxName(element.name, element.value);
-  const checked = !!ActorController.getActorField(props.id, key, props.properties);
+  const checked = !!ActorController.getActorField(props.renderID, key, props.properties);
 
   /**
    * Handles the onChange event in the radio buttons. Updates the ActorController values
    * @param ev The triggering onChange event
    */
   function onChange(ev: React.ChangeEvent<HTMLInputElement>) {
-    ActorController.updateActorField(props.id, key, props.properties, ev.target.checked);
-    ev.target.checked = !!ActorController.getActorField(props.id, key, props.properties);
+    ActorController.updateActorField(props.renderID, key, props.properties, ev.target.checked);
+    ev.target.checked = !!ActorController.getActorField(props.renderID, key, props.properties);
   }
 
   // Handles the case where we have two or more elements of the same name, and one of them is changed
@@ -36,8 +36,8 @@ export const SheetCheckbox = observer((props: SheetElementProps<CheckboxDescript
   React.useEffect(() => {
     if (!ref.current) { return; }
     if (ref.current === document.activeElement) { return; }
-    ref.current.checked = !!ActorController.getActorField(props.id, key, props.properties);
-  }, [ActorController.getActorField(props.id, key, props.properties)]);
+    ref.current.checked = !!ActorController.getActorField(props.renderID, key, props.properties);
+  }, [ActorController.getActorField(props.renderID, key, props.properties)]);
 
   return (
     <input

--- a/src/nodes/actor-sheets/components/elements/Children.tsx
+++ b/src/nodes/actor-sheets/components/elements/Children.tsx
@@ -1,0 +1,30 @@
+import { SheetElementProps } from "nodes/actor-sheets/types";
+import React from "react";
+import { SheetElement } from "../SheetElement";
+
+/**
+ * Renders out the children of a sheet element in a consistent way. This removes the need to loop in
+ * every element that has children and prevents duplicate code
+ */
+export function SheetChildren(props: SheetElementProps<any>) {
+  const elements = props.element.children || [];
+  const children: JSX.Element[] = [];
+
+  for (const element of elements) {
+    const key = props.properties.$prefix + element.$key;
+    console.log(key)
+    children.push(
+      <SheetElement
+        key={key}
+        $key={key}
+        renderID={props.renderID}
+        element={element}
+        properties={props.properties}
+      />
+    );
+  }
+
+  return (
+    <>{children}</>
+  );
+}

--- a/src/nodes/actor-sheets/components/elements/Collapse.tsx
+++ b/src/nodes/actor-sheets/components/elements/Collapse.tsx
@@ -4,7 +4,7 @@ import { StateType } from "nodes/actor-sheets/enums/stateTypes";
 import { SheetElementProps } from "nodes/actor-sheets/types";
 import { CollapseDescriptor } from "nodes/actor-sheets/types/elements";
 import React from "react";
-import { SheetElement } from "../SheetElement";
+import { SheetChildren } from "./Children";
 
 const VARIABLE_FIELDS = ["id"];
 
@@ -14,24 +14,18 @@ const VARIABLE_FIELDS = ["id"];
  */
 export const SheetCollapse = observer((props: SheetElementProps<CollapseDescriptor>) => {
   const element = ActorController.renderVariables<CollapseDescriptor>(
-    props.id,
+    props.renderID,
     props.element,
     VARIABLE_FIELDS,
     props.properties,
   );
 
   // Renders nothing if the state is false
-  if (!ActorController.getState(props.id, StateType.Collapse, element.id)) { return <></>; }
-
-  const childElements = props.element.children || [];
-  const elements: JSX.Element[] = [];
-  for (const childElement of childElements) {
-    elements.push(<SheetElement key={props.properties.$prefix + childElement.$key} {...props} element={childElement}/>);
-  }
+  if (!ActorController.getState(props.renderID, StateType.Collapse, element.id)) { return <></>; }
 
   return (
     <>
-      {elements}
+      <SheetChildren {...props}/>
     </>
   );
 });

--- a/src/nodes/actor-sheets/components/elements/Column.tsx
+++ b/src/nodes/actor-sheets/components/elements/Column.tsx
@@ -1,22 +1,17 @@
 import React from "react";
 import { ColumnDescriptor } from "nodes/actor-sheets/types/elements/column";
-import { SheetElement } from "../SheetElement";
 import style from "../../styles/Column.module.scss";
 import { SheetElementProps } from "../../types";
+import { SheetChildren } from "./Children";
 
 /**
  * Renders a checkbox input element
  * @param element The checkbox element description
  */
 export function SheetColumn(props: SheetElementProps<ColumnDescriptor>) {
-  const childElements = props.element.children || [];
-  const elements: JSX.Element[] = [];
-  for (const childElement of childElements) {
-    elements.push(<SheetElement key={props.properties.$prefix + childElement.$key} {...props} element={childElement}/>);
-  }
   return (
     <div className={`${style.column}`} style={{flexGrow: props.element.weight}}>
-      {elements}
+      <SheetChildren {...props}/>
     </div>
   );
 }

--- a/src/nodes/actor-sheets/components/elements/Inline.tsx
+++ b/src/nodes/actor-sheets/components/elements/Inline.tsx
@@ -1,22 +1,17 @@
 import React from "react";
 import { InlineDescriptor } from "nodes/actor-sheets/types/elements";
-import { SheetElement } from "../SheetElement";
 import { SheetElementProps } from "../../types";
+import { SheetChildren } from "./Children";
 
 /**
  * Renders an inline element that indicates that the contents will be rendered inline
  * @param element The inline element description
  */
 export function SheetInline(props: SheetElementProps<InlineDescriptor>) {
-  const childElements = props.element.children || [];
-  const elements: JSX.Element[] = [];
-  for (const childElement of childElements) {
-    elements.push(<SheetElement key={props.properties.$prefix + childElement.$key} {...props} element={childElement}/>);
-  }
   return (
     <div style={{ display: "block" }}>
       <div style={{display: "flex"}}>
-        {elements}
+        <SheetChildren {...props} />
       </div>
     </div>
   );

--- a/src/nodes/actor-sheets/components/elements/Input.tsx
+++ b/src/nodes/actor-sheets/components/elements/Input.tsx
@@ -22,7 +22,7 @@ interface SheetInputProps extends IndividualSheetInputProps {
 const SheetInput = observer((props: SheetInputProps) => {
   const ref = React.createRef<HTMLInputElement>();
   const element = ActorController.renderVariables<TextInputDescriptor>(
-    props.id,
+    props.renderID,
     props.element,
     VARIABLE_FIELDS,
     props.properties,
@@ -33,8 +33,8 @@ const SheetInput = observer((props: SheetInputProps) => {
    * @param ev The triggering onChange event
    */
   function onChange(e: React.ChangeEvent<HTMLInputElement>) {
-    ActorController.updateActorField(props.id, element.name, props.properties, e.target.value);
-    e.target.value = ActorController.getActorField(props.id, element.name, props.properties).toString();
+    ActorController.updateActorField(props.renderID, element.name, props.properties, e.target.value);
+    e.target.value = ActorController.getActorField(props.renderID, element.name, props.properties).toString();
   }
 
   // Handles the case where we have two or more elements of the same name, and one of them is changed
@@ -42,8 +42,8 @@ const SheetInput = observer((props: SheetInputProps) => {
   React.useEffect(() => {
     if (!ref.current) { return; }
     if (ref.current === document.activeElement) { return; }
-    ref.current.value = ActorController.getActorField(props.id, element.name, props.properties).toString();
-  }, [ActorController.getActorField(props.id, element.name, props.properties)]);
+    ref.current.value = ActorController.getActorField(props.renderID, element.name, props.properties).toString();
+  }, [ActorController.getActorField(props.renderID, element.name, props.properties)]);
 
   return (
     <div>
@@ -55,7 +55,7 @@ const SheetInput = observer((props: SheetInputProps) => {
         className={`${style.actorSheetInput}`}
         onChange={onChange}
         autoComplete="off"
-        defaultValue={ActorController.getActorField(props.id, element.name, props.properties).toString()}
+        defaultValue={ActorController.getActorField(props.renderID, element.name, props.properties).toString()}
       />
     </div>
   );

--- a/src/nodes/actor-sheets/components/elements/Label.tsx
+++ b/src/nodes/actor-sheets/components/elements/Label.tsx
@@ -12,7 +12,7 @@ const VARIABLE_FIELDS = ["for", "text"];
  */
 export const SheetLabel = observer((props: SheetElementProps<LabelDescriptor>) => {
   const element = ActorController.renderVariables<LabelDescriptor>(
-    props.id,
+    props.renderID,
     props.element,
     VARIABLE_FIELDS,
     props.properties,

--- a/src/nodes/actor-sheets/components/elements/Loop.tsx
+++ b/src/nodes/actor-sheets/components/elements/Loop.tsx
@@ -4,30 +4,7 @@ import { SheetElementProps, SheetProperties } from "nodes/actor-sheets/types";
 import { LoopDescriptor } from "nodes/actor-sheets/types/elements/loop";
 import { Expression } from "nodes/actor-sheets/types/expressions";
 import React from "react";
-import { SheetElement } from "../SheetElement";
-
-/**
- * Renders each item of a loop
- */
-function SheetLoopItem(props: SheetElementProps<LoopDescriptor>) {
-  const childElements = props.element.children || [];
-  const elements: JSX.Element[] = [];
-  for (const childElement of childElements) {
-    elements.push(
-      <SheetElement
-        key={props.properties.$prefix + childElement.$key}
-        id={props.id}
-        element={childElement}
-        properties={props.properties}
-      />
-    );
-  }
-  return (
-    <>
-      {elements}
-    </>
-  );
-}
+import { SheetChildren } from "./Children";
 
 /**
  * Loops through a given list and prints the contained elements repeatedly
@@ -44,7 +21,7 @@ export const SheetLoop = observer((props: SheetElementProps<LoopDescriptor>) => 
     // TODO - fix this super jank variable name get
     variableName = (props.element.list[0] as Expression).items[0].value;
     list = ActorController.convertVariableToData(
-      props.id,
+      props.renderID,
       variableName || "",
       props.properties as any
     ) as (string | Record<string, string>)[];
@@ -58,15 +35,14 @@ export const SheetLoop = observer((props: SheetElementProps<LoopDescriptor>) => 
       ...props.properties,
       $source: { ...props.properties.$source },
       $index: {...props.properties.$index, [key]: i },
+      $prefix: prefix,
       [key]: listItem,
     };
     if (variableName) { properties.$source[key] = variableName; }
 
     if (props.element.index) { properties[props.element.index] = i; }
 
-    loopedElements.push(
-      <SheetLoopItem key={prefix} {...props} properties={properties}/>
-    );
+    loopedElements.push(<SheetChildren key={prefix} {...props} properties={properties}/>);
     i++;
   }
 

--- a/src/nodes/actor-sheets/components/elements/Option.tsx
+++ b/src/nodes/actor-sheets/components/elements/Option.tsx
@@ -12,7 +12,7 @@ const VARIABLE_FIELDS = ["value", "text"];
  */
 export const SheetOption = observer((props: SheetElementProps<OptionDescriptor>) => {
   const element = ActorController.renderVariables<OptionDescriptor>(
-    props.id,
+    props.renderID,
     props.element,
     VARIABLE_FIELDS,
     props.properties,

--- a/src/nodes/actor-sheets/components/elements/Page.tsx
+++ b/src/nodes/actor-sheets/components/elements/Page.tsx
@@ -1,21 +1,16 @@
 import React from "react";
 import { PageDescriptor } from "nodes/actor-sheets/types/elements";
-import { SheetElement } from "../SheetElement";
 import { SheetElementProps } from "../../types";
+import { SheetChildren } from "./Children";
 
 /**
  * Renders an image of the background
  * @param element The SheetBackground element description
  */
 export function SheetPage(props: SheetElementProps<PageDescriptor>) {
-  const childElements = props.element.children || [];
-  const elements: JSX.Element[] = [];
-  for (const childElement of childElements) {
-    elements.push(<SheetElement key={props.properties.$prefix + childElement.$key} {...props} element={childElement}/>);
-  }
   return (
     <div>
-      {elements}
+      <SheetChildren {...props} />
     </div>
   );
 }

--- a/src/nodes/actor-sheets/components/elements/Pageable.tsx
+++ b/src/nodes/actor-sheets/components/elements/Pageable.tsx
@@ -6,13 +6,14 @@ import { SheetPage } from "./Page";
 import { StateType } from "nodes/actor-sheets/enums/stateTypes";
 import { ActorController } from "nodes/actor-sheets/controllers/ActorController";
 import { observer } from "mobx-react-lite";
+import { SheetChildren } from "./Children";
 
 /**
  * Renders an image of the background
  * @param element The SheetBackground element description
  */
 export const SheetPageable = observer((props: SheetElementProps<PageableDescriptor>) => {
-  const activeTab = ActorController.getState(props.id, StateType.CurrentPage, props.element.id) as number || 0;
+  const activeTab = ActorController.getState(props.renderID, StateType.CurrentPage, props.element.id) as number || 0;
   const childElements = props.element.children || [];
 
   // Renders all the children that are not part of the pageable pages themself
@@ -26,7 +27,7 @@ export const SheetPageable = observer((props: SheetElementProps<PageableDescript
   return (
     <div>
       <SheetPage {...props} element={props.element.pages[activeTab]}/>
-      {nonPageChildren}
+      <SheetChildren {...props} />
     </div>
   );
 });

--- a/src/nodes/actor-sheets/components/elements/Prefab.tsx
+++ b/src/nodes/actor-sheets/components/elements/Prefab.tsx
@@ -1,22 +1,16 @@
 import React from "react";
 import { PrefabDescriptor } from "nodes/actor-sheets/types/elements";
-import { SheetElement } from "../SheetElement";
 import { SheetElementProps } from "../../types";
+import { SheetChildren } from "./Children";
 
 /**
  * Renders an image of the prefab
  * @param element The SheetPrefab element description
  */
 export function SheetPrefab(props: SheetElementProps<PrefabDescriptor>) {
-  const childElements = props.element.children || [];
-  const elements: JSX.Element[] = [];
-  for (const childElement of childElements) {
-    elements.push(<SheetElement key={props.properties.$prefix + childElement.$key} {...props} element={childElement}/>);
-  }
-
   return (
     <div>
-      {elements}
+      <SheetChildren {...props}/>
     </div>
   );
 }

--- a/src/nodes/actor-sheets/components/elements/RadioButton.tsx
+++ b/src/nodes/actor-sheets/components/elements/RadioButton.tsx
@@ -13,19 +13,19 @@ const VARIABLE_FIELDS = ["id", "name", "value"];
 export const SheetRadioButton = observer((props: SheetElementProps<RadioDescriptor>) => {
   const ref = React.createRef<HTMLInputElement>();
   const element = ActorController.renderVariables<RadioDescriptor>(
-    props.id,
+    props.renderID,
     props.element,
     VARIABLE_FIELDS,
     props.properties,
   );
-  const fieldValue = ActorController.getActorField(props.id, element.name, props.properties);
+  const fieldValue = ActorController.getActorField(props.renderID, element.name, props.properties);
 
   /**
    * Handles the onChange event in the radio buttons. Updates the ActorController values
    * @param ev The triggering onChange event
    */
   function onChange(ev: React.ChangeEvent<HTMLInputElement>) {
-    ActorController.updateActorField(props.id, element.name, props.properties, ev.target.value);
+    ActorController.updateActorField(props.renderID, element.name, props.properties, ev.target.value);
     ev.target.checked = true;
   }
 

--- a/src/nodes/actor-sheets/components/elements/Row.tsx
+++ b/src/nodes/actor-sheets/components/elements/Row.tsx
@@ -1,22 +1,17 @@
 import React from "react";
 import { RowDescriptor } from "nodes/actor-sheets/types/elements";
-import { SheetElement } from "../SheetElement";
 import style from "../../styles/Row.module.scss";
 import { SheetElementProps } from "../../types";
+import { SheetChildren } from "./Children";
 
 /**
  * Renders a row element
  * @param element The row element description
  */
 export function SheetRow(props: SheetElementProps<RowDescriptor>) {
-  const childElements = props.element.children || [];
-  const elements: JSX.Element[] = [];
-  for (const childElement of childElements) {
-    elements.push(<SheetElement key={props.properties.$prefix + childElement.$key} {...props} element={childElement}/>);
-  }
   return (
     <div className={`${style.row}`} style={{}}>
-      {elements}
+      <SheetChildren {...props}/>
     </div>
   );
 }

--- a/src/nodes/actor-sheets/components/elements/Select.tsx
+++ b/src/nodes/actor-sheets/components/elements/Select.tsx
@@ -2,7 +2,7 @@ import { ActorController } from "../../controllers/ActorController";
 import React from "react";
 import { SelectDescriptor } from "nodes/actor-sheets/types/elements";
 import { SheetElementProps } from "nodes/actor-sheets/types";
-import { SheetElement } from "../SheetElement";
+import { SheetChildren } from "./Children";
 
 const VARIABLE_FIELDS = ["id", "name"];
 
@@ -12,34 +12,28 @@ const VARIABLE_FIELDS = ["id", "name"];
  */
 export function SheetSelect(props: SheetElementProps<SelectDescriptor>) {
   const element = ActorController.renderVariables<SelectDescriptor>(
-    props.id,
+    props.renderID,
     props.element,
     VARIABLE_FIELDS,
     props.properties
   );
-
-  const childElements = props.element.children || [];
-  const elements: JSX.Element[] = [];
-  for (const childElement of childElements) {
-    elements.push(<SheetElement key={props.properties.$prefix + childElement.$key} {...props} element={childElement}/>);
-  }
 
   /**
    * Updates the ActorController to have the changed values
    * @param ev The triggering onChange event
    */
    function onChange(ev: React.ChangeEvent<HTMLSelectElement>) {
-    ActorController.updateActorField(props.id, element.name, props.properties, ev.target.value);
-    ev.target.value = ActorController.getActorField(props.id, element.name, props.properties).toString();
+    ActorController.updateActorField(props.renderID, element.name, props.properties, ev.target.value);
+    ev.target.value = ActorController.getActorField(props.renderID, element.name, props.properties).toString();
   }
 
   return (
     <select
       name={element.name}
-      defaultValue={ActorController.getActorField(props.id, element.name, props.properties).toString()}
+      defaultValue={ActorController.getActorField(props.renderID, element.name, props.properties).toString()}
       onChange={onChange}
     >
-      {elements}
+      <SheetChildren {...props}/>
     </select>
   );
 }

--- a/src/nodes/actor-sheets/components/elements/Table.tsx
+++ b/src/nodes/actor-sheets/components/elements/Table.tsx
@@ -1,22 +1,17 @@
 import React from "react";
 import { TableDescriptor } from "nodes/actor-sheets/types/elements";
-import { SheetElement } from "../SheetElement";
 import { SheetElementProps } from "../../types";
+import { SheetChildren } from "./Children";
 
 /**
  * Renders an table element
  * @param element The table element description
  */
 export function SheetTable(props: SheetElementProps<TableDescriptor>) {
-  const childElements = props.element.children || [];
-  const elements: JSX.Element[] = [];
-  for (const childElement of childElements) {
-    elements.push(<SheetElement key={props.properties.$prefix + childElement.$key} {...props} element={childElement}/>);
-  }
   return (
     <table >
       <tbody>
-        {elements}
+        <SheetChildren {...props}/>
       </tbody>
     </table>
   );

--- a/src/nodes/actor-sheets/components/elements/TableCell.tsx
+++ b/src/nodes/actor-sheets/components/elements/TableCell.tsx
@@ -1,21 +1,16 @@
 import React from "react";
 import { TableCellDescriptor } from "nodes/actor-sheets/types/elements";
-import { SheetElement } from "../SheetElement";
 import { SheetElementProps } from "../../types";
+import { SheetChildren } from "./Children";
 
 /**
  * Renders an table cell element
  * @param element The table cell element description
  */
 export function SheetTableCell(props: SheetElementProps<TableCellDescriptor>) {
-  const childElements = props.element.children || [];
-  const elements: JSX.Element[] = [];
-  for (const childElement of childElements) {
-    elements.push(<SheetElement key={props.properties.$prefix + childElement.$key} {...props} element={childElement}/>);
-  }
   return (
     <td colSpan={props.element.width}>
-      {elements}
+      <SheetChildren {...props}/>
     </td>
   );
 }

--- a/src/nodes/actor-sheets/components/elements/TableRow.tsx
+++ b/src/nodes/actor-sheets/components/elements/TableRow.tsx
@@ -1,21 +1,16 @@
 import React from "react";
 import { TableRowDescriptor } from "nodes/actor-sheets/types/elements";
-import { SheetElement } from "../SheetElement";
 import { SheetElementProps } from "../../types";
+import { SheetChildren } from "./Children";
 
 /**
  * Renders an table row element
  * @param element The table row element description
  */
 export function SheetTableRow(props: SheetElementProps<TableRowDescriptor>) {
-  const childElements = props.element.children || [];
-  const elements: JSX.Element[] = [];
-  for (const childElement of childElements) {
-    elements.push(<SheetElement key={props.properties.$prefix + childElement.$key} {...props} element={childElement}/>);
-  }
   return (
     <tr >
-      {elements}
+      <SheetChildren {...props}/>
     </tr>
   );
 }

--- a/src/nodes/actor-sheets/components/elements/Tabs.tsx
+++ b/src/nodes/actor-sheets/components/elements/Tabs.tsx
@@ -41,9 +41,9 @@ function SheetTab(props: SheetTabProps) {
  * @param element The tabs element description
  */
 export const SheetTabs = observer((props: SheetElementProps<TabsDescriptor>) => {
-  const tabs = ActorController.getTabs(props.id, props.element.for) as { name: string }[];
+  const tabs = ActorController.getTabs(props.renderID, props.element.for) as { name: string }[];
 
-  let activeTab = ActorController.getState(props.id, StateType.CurrentPage, props.element.for) || 0;
+  let activeTab = ActorController.getState(props.renderID, StateType.CurrentPage, props.element.for) || 0;
   if (typeof activeTab === "string") { activeTab = parseInt(activeTab); }
   else if (typeof activeTab !== "number" ) { activeTab = 0; }
 
@@ -58,7 +58,7 @@ export const SheetTabs = observer((props: SheetElementProps<TabsDescriptor>) => 
 
   // Sets the active tab state
   function setActiveTab(index: number) {
-    ActorController.setState(props.id, StateType.CurrentPage, props.element.for, index);
+    ActorController.setState(props.renderID, StateType.CurrentPage, props.element.for, index);
   }
 
   const tabElements: JSX.Element[] = [];

--- a/src/nodes/actor-sheets/components/elements/TextArea.tsx
+++ b/src/nodes/actor-sheets/components/elements/TextArea.tsx
@@ -13,7 +13,7 @@ const VARIABLE_FIELDS = ["id", "name"];
 export function SheetTextArea(props: SheetElementProps<TextAreaDescriptor>) {
   const ref = React.createRef<HTMLTextAreaElement>();
   const element = ActorController.renderVariables<TextAreaDescriptor>(
-    props.id,
+    props.renderID,
     props.element,
     VARIABLE_FIELDS,
     props.properties,
@@ -24,8 +24,8 @@ export function SheetTextArea(props: SheetElementProps<TextAreaDescriptor>) {
    * @param ev The triggering onChange event
    */
   function onChange(ev: React.ChangeEvent<HTMLTextAreaElement>) {
-    ActorController.updateActorField(props.id, element.name, props.properties, ev.target.value);
-    ev.target.value = ActorController.getActorField(props.id, element.name, props.properties).toString();
+    ActorController.updateActorField(props.renderID, element.name, props.properties, ev.target.value);
+    ev.target.value = ActorController.getActorField(props.renderID, element.name, props.properties).toString();
   }
 
   // Handles the case where we have two or more elements of the same name, and one of them is changed
@@ -33,8 +33,8 @@ export function SheetTextArea(props: SheetElementProps<TextAreaDescriptor>) {
   React.useEffect(() => {
     if (!ref.current) { return; }
     if (ref.current === document.activeElement) { return; }
-    ref.current.value = ActorController.getActorField(props.id, element.name, props.properties).toString();
-  }, [ActorController.getActorField(props.id, element.name, props.properties)]);
+    ref.current.value = ActorController.getActorField(props.renderID, element.name, props.properties).toString();
+  }, [ActorController.getActorField(props.renderID, element.name, props.properties)]);
 
   return (
     <div>
@@ -45,7 +45,7 @@ export function SheetTextArea(props: SheetElementProps<TextAreaDescriptor>) {
         onChange={onChange}
         className={`${style.actorSheetInput}`}
         rows={4}
-        defaultValue={ActorController.getActorField(props.id, element.name, props.properties).toString()}
+        defaultValue={ActorController.getActorField(props.renderID, element.name, props.properties).toString()}
       />
     </div>
   );

--- a/src/nodes/actor-sheets/types/index.ts
+++ b/src/nodes/actor-sheets/types/index.ts
@@ -2,7 +2,8 @@ import { GenericSheetElementDescriptor } from "nodes/actor-sheets/types/elements
 import { Scalar } from "types";
 
 export interface SheetElementProps<T extends GenericSheetElementDescriptor> {
-  id: string;
+  $key: string; // The key used to identify the element in a loop
+  renderID: string; // The ID used for this current render
   element: T;
   properties: SheetProperties;
 }

--- a/src/nodes/actor-sheets/utilities/parse/children.ts
+++ b/src/nodes/actor-sheets/utilities/parse/children.ts
@@ -13,12 +13,13 @@ export function parseChildrenElements(elements: HTMLCollection, state: SheetStat
   const counts: Record<string, number> = {};
 
   for (const element of elements) {
+    const newState = { ...state };
     // Counts the tags to ensure unique keys at this level
     const tag = element.tagName.toLocaleLowerCase();
     if (counts[tag] === undefined) { counts[tag] = 0; }
-    state.key += `-${tag}_${counts[tag]}`;
+    newState.key += `-${tag}_${counts[tag]}`;
 
-    const child = parseUnknownElement(element, state);
+    const child = parseUnknownElement(element, newState);
 
     if (!child) { continue; }
     children.push(child);

--- a/src/nodes/actor-sheets/utilities/parse/tabs.ts
+++ b/src/nodes/actor-sheets/utilities/parse/tabs.ts
@@ -1,7 +1,6 @@
 import { SheetElementType } from "nodes/actor-sheets/enums/sheetElementType";
 import { SheetState } from "nodes/actor-sheets/types";
 import { TabsDescriptor } from "nodes/actor-sheets/types/elements";
-import { parseChildrenElements } from "./children";
 
 /**
  * Converts a row element into a row element descriptor


### PR DESCRIPTION
Changes
- Adds \<SheetChildren/\> element for rendering SheetElements in a loop in a single place. 
- Renames SheetElementProps 'id' to 'renderID' to be clearer as to the contents of the ID

Depends on #251 