### PR TITLE
Split StaticVariables into two subobjects for easier access

### DIFF
--- a/src/@owl-factory/data/DataManager.ts
+++ b/src/@owl-factory/data/DataManager.ts
@@ -314,8 +314,8 @@ export class DataManager<T extends Record<string, unknown>> {
     if (!Array.isArray(docs)) { docs = [docs]; }
 
     const packets = await crud.update<T>(this.url, docs);
-    const createdDocs = getSuccessfulDocuments(packets);
-    this.setMany(createdDocs);
+    const updatedDocs = getSuccessfulDocuments(packets);
+    this.setMany(updatedDocs);
     return packets;
   }
 

--- a/src/components/reroll/forms/staticVariables/StaticVariableInput.tsx
+++ b/src/components/reroll/forms/staticVariables/StaticVariableInput.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import { StaticVariable } from "types/documents/subdocument/StaticVariable";
+import { StaticVariableMetadata, StaticVariables } from "types/documents/subdocument/StaticVariable";
 import { StaticVariableForm } from "./StaticVariableForm";
 import { StaticVariableList } from "./StaticVariableList";
 
 interface StaticVariableInput {
-  staticVariables: Record<string, StaticVariable>;
-  setStaticVariables: (staticVariables: Record<string, StaticVariable>) => void;
+  variables: StaticVariables;
+  setVariables: (staticVariables: StaticVariables) => void;
 }
 
 /**
@@ -14,22 +14,22 @@ interface StaticVariableInput {
  * @param setStaticVariables A function to update the static variables
  */
 export function StaticVariableInput(props: StaticVariableInput) {
-  const [ selectedVariable, setSelectedVariable ] = React.useState<string | undefined>(undefined);
+  const [ selected, setSelected ] = React.useState<string | undefined>(undefined);
   return (
     <div>
       <h2>Static Variables</h2>
       <div style={{display: "flex"}}>
         <StaticVariableList
-          staticVariables={props.staticVariables}
-          setStaticVariables={props.setStaticVariables}
-          selectedVariable={selectedVariable}
-          setSelectedVariable={setSelectedVariable}
+          variables={props.variables}
+          setVariables={props.setVariables}
+          selected={selected}
+          setSelected={setSelected}
         />
         <StaticVariableForm
-          staticVariables={props.staticVariables}
-          setStaticVariables={props.setStaticVariables}
-          selectedVariable={selectedVariable}
-          setSelectedVariable={setSelectedVariable}
+          variables={props.variables}
+          setVariables={props.setVariables}
+          selected={selected}
+          setSelected={setSelected}
         />
       </div>
     </div>

--- a/src/components/reroll/forms/staticVariables/StaticVariableList.tsx
+++ b/src/components/reroll/forms/staticVariables/StaticVariableList.tsx
@@ -1,14 +1,17 @@
 import { Button } from "@owl-factory/components/button";
 import React from "react";
-import { StaticVariable, StaticVariableScalarType } from "types/documents/subdocument/StaticVariable";
+import {
+  StaticVariableScalarType,
+  StaticVariables,
+} from "types/documents/subdocument/StaticVariable";
 import { getNextUntitled } from "utilities/helpers";
 import styles from "./StaticVariableList.module.scss";
 
 interface StaticVariableListProps {
-  staticVariables: Record<string, StaticVariable>;
-  setStaticVariables: (staticVariables: Record<string, StaticVariable>) => void;
-  selectedVariable: string | undefined;
-  setSelectedVariable: (key: string | undefined) => void;
+  variables: StaticVariables;
+  setVariables: (staticVariables: StaticVariables) => void;
+  selected: string | undefined;
+  setSelected: (key: string | undefined) => void;
 }
 
 /**
@@ -23,31 +26,36 @@ export function StaticVariableList(props: StaticVariableListProps) {
    * Adds a new static variable
    */
   function addVariable() {
-    const keys = Object.keys(props.staticVariables);
+    const keys = Object.keys(props.variables.metadata);
     const untitledKey = getNextUntitled(keys);
 
-    const newVariable = {
+    const newMetadata = {
       name: "Untitled",
       key: untitledKey,
       description: "",
       variableType: StaticVariableScalarType.String,
-      value: "",
     };
 
-    const staticVariables = {...props.staticVariables, [untitledKey]: newVariable };
-    props.setStaticVariables(staticVariables);
-    props.setSelectedVariable(untitledKey);
+    const newValue = "";
+
+    const metadata = {...props.variables.metadata, [untitledKey]: newMetadata };
+    const values = { ...props.variables.values, [untitledKey]: newValue };
+    props.setVariables({ metadata, values});
+    props.setSelected(untitledKey);
   }
 
   /**
    * Removes the currently selected static variable
    */
   function removeVariable() {
-    if (!props.selectedVariable) { return; }
-    const staticVariables = { ...props.staticVariables };
-    (staticVariables[props.selectedVariable] as any) = null;
-    props.setStaticVariables(staticVariables);
-    props.setSelectedVariable(undefined);
+    if (!props.selected) { return; }
+    const values = { ...props.variables.values };
+    const metadata = { ...props.variables.metadata };
+
+    (values[props.selected] as any) = null;
+    (metadata[props.selected] as any) = null;
+    props.setVariables({ metadata, values });
+    props.setSelected(undefined);
   }
 
   /**
@@ -55,26 +63,26 @@ export function StaticVariableList(props: StaticVariableListProps) {
    * @param key The key of the variable to select
    */
   function selectVariable(key: string | undefined) {
-    if (key === props.selectedVariable) {
-      props.setSelectedVariable(undefined);
+    if (key === props.selected) {
+      props.setSelected(undefined);
       return;
     }
-    props.setSelectedVariable(key);
+    props.setSelected(key);
   }
 
   const items: JSX.Element[] = [];
-  const keys = Object.keys(props.staticVariables).sort();
+  const keys = Object.keys(props.variables.metadata).sort();
   for (const key of keys) {
     // Skip if this field is deleted or renamed
-    if (props.staticVariables[key] === null) { continue; }
-    const className = props.selectedVariable === key ? styles.active : "";
+    if (props.variables.metadata[key] === null) { continue; }
+    const className = props.selected === key ? styles.active : "";
     items.push(
       <div
         key={key}
         className={className}
         onClick={() => selectVariable(key)}
       >
-        {props.staticVariables[key].name} ({props.staticVariables[key].key})
+        {props.variables.metadata[key].name} ({props.variables.metadata[key].key})
       </div>
     );
   }

--- a/src/components/reroll/forms/staticVariables/StaticVariableValueInput.tsx
+++ b/src/components/reroll/forms/staticVariables/StaticVariableValueInput.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 import {
-  StaticVariable,
   StaticVariableComplexType,
+  StaticVariableMetadata,
   StaticVariableScalarType,
-  StaticVariableType,
 } from "types/documents/subdocument/StaticVariable";
 import { StaticVariableScalarArrayInput } from "./inputs/ScalarArrayInput";
 import { StaticVariableBooleanInput } from "./inputs/BooleanInput";
@@ -14,7 +13,7 @@ import { StaticVariableObjectArrayInput } from "./inputs/ObjectArrayInput";
 import { StaticVariableFormValues, StaticVariableObject } from "types/components/forms/staticVariables";
 
 interface StaticVariableValueInputProps {
-  staticVariable: StaticVariable & StaticVariableFormValues;
+  staticVariable: StaticVariableMetadata & StaticVariableFormValues;
   setStaticVariableField: (field: string, value: any, shouldValidate?: boolean | undefined) => void;
 }
 

--- a/src/components/reroll/forms/staticVariables/inputs/ObjectArrayInput.tsx
+++ b/src/components/reroll/forms/staticVariables/inputs/ObjectArrayInput.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@owl-factory/components/button";
 import React from "react";
 import { StaticVariableFormValues, StaticVariableObject } from "types/components/forms/staticVariables";
-import { StaticVariable } from "types/documents/subdocument/StaticVariable";
+import { StaticVariableMetadata } from "types/documents/subdocument/StaticVariable";
 import { StaticVariableObjectInput } from "./ObjectInput";
 import { ObjectTypeInput } from "./ObjectTypeInput";
 
@@ -50,7 +50,7 @@ function ObjectArrayInput(props: ObjectArrayInputProps) {
 }
 
 interface StaticVariableObjectArrayInputProps {
-  staticVariable: StaticVariable & StaticVariableFormValues;
+  staticVariable: StaticVariableMetadata & StaticVariableFormValues;
   setStaticVariableField: (field: string, value: any, shouldValidate?: boolean | undefined) => void;
 }
 

--- a/src/components/reroll/forms/staticVariables/inputs/ScalarArrayInput.tsx
+++ b/src/components/reroll/forms/staticVariables/inputs/ScalarArrayInput.tsx
@@ -3,12 +3,12 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "c
 import { Formik, FormikProps } from "formik";
 import React from "react";
 import { StaticVariableFormValues } from "types/components/forms/staticVariables";
-import { StaticVariable, StaticVariableComplexType } from "types/documents/subdocument/StaticVariable";
+import { StaticVariableComplexType, StaticVariableMetadata } from "types/documents/subdocument/StaticVariable";
 import { StaticVariableNumberInput } from "./NumberInput";
 import { StaticVariableTextInput } from "./TextInput";
 
 interface StaticVariableScalarArrayInputProps {
-  staticVariable: StaticVariable & StaticVariableFormValues;
+  staticVariable: StaticVariableMetadata & StaticVariableFormValues;
   setStaticVariableField: (field: string, value: any, shouldValidate?: boolean | undefined) => void;
 }
 

--- a/src/components/reroll/rulesets/Form.tsx
+++ b/src/components/reroll/rulesets/Form.tsx
@@ -66,8 +66,8 @@ export function RulesetForm(props: { ruleset?: Partial<RulesetDocument> }) {
 
           <CustomFieldInput field="actorFields" onChange={formikProps.setFieldValue} values={formikProps.values}/>
           <StaticVariableInput
-            staticVariables={formikProps.values.staticVariables || {}}
-            setStaticVariables={(staticVariables) => formikProps.setFieldValue("staticVariables", staticVariables)}
+            variables={formikProps.values.rules || { metadata: {}, values: {} }}
+            setVariables={(rules) => formikProps.setFieldValue("rules", rules)}
           />
           <Button type="button" onClick={() => formikProps.resetForm}>Reset</Button>
           <Button type="submit">Submit</Button>

--- a/src/controllers/data/RulesetData.ts
+++ b/src/controllers/data/RulesetData.ts
@@ -43,7 +43,7 @@ class RulesetDataManager extends DataManager<Partial<RulesetDocument>> {
     validateUpdatedRuleset(doc);
 
     const packets = await super.$update(doc);
-    if (packets.length === 0) { throw `An unexpected error occured when creating the document ${doc.name}`; }
+    if (packets.length === 0) { throw `An unexpected error occured when updating the ruleset document ${doc.name}`; }
     else if (!packets[0].success) { throw packets[0].messages; }
     return packets[0].doc as Partial<RulesetDocument>;
   }

--- a/src/nodes/actor-sheets/controllers/ActorController.ts
+++ b/src/nodes/actor-sheets/controllers/ActorController.ts
@@ -354,7 +354,7 @@ class $ActorController {
       actor: toJS(this.actorController.getActorValues(actorRef)),
       character: toJS(this.actorController.getActorValues(actorRef)),
       content: toJS(this.actorController.getAllContent(actorRef)),
-      rules: toJS(this.rulesetController.getRuleset(rulesetRef).staticVariables),
+      rules: toJS(this.rulesetController.getRuleset(rulesetRef).rules.values),
       sheet: toJS(this.sheetController.getAllVariables(sheetRef)),
       expr: expr.value,
       _key: key,

--- a/src/nodes/actor-sheets/controllers/RulesetController.ts
+++ b/src/nodes/actor-sheets/controllers/RulesetController.ts
@@ -1,13 +1,13 @@
 import { read } from "@owl-factory/utilities/objects";
 import { action, makeObservable, observable } from "mobx";
 import { RulesetDocument } from "types/documents";
-import { StaticVariable } from "types/documents/subdocument/StaticVariable";
+import { StaticVariables } from "types/documents/subdocument/StaticVariable";
 
 interface RulesetControllerItem {
   name: string; // The name of the ruleset
   alias: string; // The name of the alias
   actorFields: Record<string, unknown>; // The actor fields
-  staticVariables: Record<string, StaticVariable>; // The custom, static variables
+  rules: StaticVariables; // The custom, static variables
 }
 
 // An empty default ruleset
@@ -15,7 +15,7 @@ const EMPTY_RULESET: RulesetControllerItem = {
   name: "Test Ruleset",
   alias: "test",
   actorFields: {},
-  staticVariables: {},
+  rules: { metadata: {}, values: {} },
 };
 
 // The types of variables stored within the ruleset
@@ -58,7 +58,7 @@ export class RulesetController {
     const ruleset = this.getRuleset(ref);
     switch (variableGroup) {
       case RuleVariableGroup.STATIC:
-        const staticField = ruleset.staticVariables;
+        const staticField = ruleset.rules.values;
         const value = read(staticField, field);
         if (!value) { return undefined; }
         return (value as any).value;
@@ -75,7 +75,8 @@ export class RulesetController {
       name: ruleset.name || "Unknown",
       alias: ruleset.alias || "unknown",
       actorFields: ruleset.actorFields || {},
-      staticVariables: ruleset.staticVariables || {},
+      rules: ruleset.rules || { metadata: {}, values: {} },
+
     };
     this.$rulesets[ref] = rules;
   }

--- a/src/nodes/actor-sheets/types/workers.ts
+++ b/src/nodes/actor-sheets/types/workers.ts
@@ -1,6 +1,6 @@
 import { Scalar } from "types";
 import { ActorContent } from "types/documents/Actor";
-import { StaticVariable } from "types/documents/subdocument/StaticVariable";
+import { StaticVariableValue } from "types/documents/subdocument/StaticVariable";
 
 // The contents of the message data to the actor sheet sandboxed web worker
 export type SandboxWorkerMessage = StaticSandboxWorkerMessage & Record<string, Scalar | unknown>;
@@ -9,6 +9,6 @@ export type SandboxWorkerMessage = StaticSandboxWorkerMessage & Record<string, S
 export interface StaticSandboxWorkerMessage {
   expr: string;
   actor: Record<string, Scalar>;
-  rules: Record<string, StaticVariable>;
+  rules: Record<string, StaticVariableValue>;
   content: Record<string, ActorContent[]>;
 }

--- a/src/types/documents/Ruleset.ts
+++ b/src/types/documents/Ruleset.ts
@@ -1,6 +1,6 @@
 import { Ref64 } from "@owl-factory/types";
 import { BaseDocument } from "./BaseDocument";
-import { StaticVariable } from "./subdocument/StaticVariable";
+import { StaticVariables } from "./subdocument/StaticVariable";
 
 export interface ActorType {
   name: string; // The name of the actor type, readable to the user ("Player Character, Non-Player Character")
@@ -17,7 +17,8 @@ export interface RulesetDocument extends BaseDocument {
   actorFields: Record<string, unknown>; // Variable names and types to be used by the actors for this ruleset
   actorTypes: ActorType[]; // The different kinds of actors supported by this ruleset by default
 
-  staticVariables: Record<string, StaticVariable>;
+  // Static variables serving as 'rules' and flags and values for the ruleset
+  rules: StaticVariables;
 
   // Indicates whether a ruleset is official or not. Official rulesets are those that are offically supported
   // on the app, be they first party (D&D 5e) or third party (Star Wars 5e).

--- a/src/types/documents/subdocument/StaticVariable.ts
+++ b/src/types/documents/subdocument/StaticVariable.ts
@@ -21,13 +21,27 @@ export type StaticVariableType = StaticVariableScalarType | StaticVariableComple
 type Scalar = string | number | boolean;
 
 // The static variable subdocument used to track variables, their names, and values
-export interface StaticVariable {
+export interface StaticVariableMetadata {
   name: string; // The human readable name of the static variable
   key: string; // The variable name of the static variable for accessing in code
   description: string; // A description for better conveying the idea of what this does
   variableType: StaticVariableType; // The type of value stored in this static variable
   objectType?: Record<string, StaticVariableScalarType>; // A definition of the object(s) stored within this variable
+}
 
-  // The value stored within the static variable
-  value: Scalar | Record<string, Scalar> | string[] | number[] | boolean[] | Record<string, Scalar>[];
+// Describes a type of data that can be used within a static variable
+export type StaticVariableValue = (
+  Scalar |
+  Record<string, Scalar> |
+  string[] |
+  number[] |
+  boolean[] |
+  Record<string, Scalar>[]
+);
+
+// Combines the static variable data into a single object for keeping the base object clean
+// and grouping shared data together
+export interface StaticVariables {
+  metadata: Record<string, StaticVariableMetadata>;
+  values: Record<string, StaticVariableValue>;
 }

--- a/src/utilities/staticVariable/helpers.ts
+++ b/src/utilities/staticVariable/helpers.ts
@@ -1,19 +1,20 @@
 import { StaticVariableFormValues, StaticVariableObject } from "types/components/forms/staticVariables";
 import {
-  StaticVariable,
+  StaticVariableValue,
   StaticVariableComplexType,
+  StaticVariableMetadata,
   StaticVariableScalarType,
 } from "types/documents/subdocument/StaticVariable";
 
 
 /**
  * Builds initial values from the default starting static variable values
- * @param staticVariable The given static variable to build initial values from
+ * @param value The given static variable to build initial values from
  */
-export function buildInitialValues(staticVariable: StaticVariable) {
-  const initialValues: StaticVariable & StaticVariableFormValues = {
-    ...staticVariable,
-    oldKey: staticVariable.key,
+export function buildInitialValues(value: StaticVariableValue, metadata: StaticVariableMetadata) {
+  const initialValues: StaticVariableMetadata & StaticVariableFormValues = {
+    ...metadata,
+    oldKey: metadata.key,
     value_string: "",
     value_number: 0,
     value_boolean: false,
@@ -27,36 +28,36 @@ export function buildInitialValues(staticVariable: StaticVariable) {
 
   let keys: string[];
 
-  switch (staticVariable.variableType) {
+  switch (metadata.variableType) {
     case StaticVariableScalarType.String:
-      initialValues.value_string = staticVariable.value as string;
+      initialValues.value_string = value as string;
       break;
     case StaticVariableScalarType.Number:
-      initialValues.value_number = staticVariable.value as number;
+      initialValues.value_number = value as number;
       break;
     case StaticVariableScalarType.Boolean:
-      initialValues.value_boolean = staticVariable.value as boolean;
+      initialValues.value_boolean = value as boolean;
       break;
     case StaticVariableComplexType.Object:
-      if (!staticVariable.objectType) { break; }
-      keys = Object.keys(staticVariable.objectType).sort();
+      if (!metadata.objectType) { break; }
+      keys = Object.keys(metadata.objectType).sort();
       for (const key of keys) {
-        const value: StaticVariableObject = {
+        const objectValue: StaticVariableObject = {
           key,
-          type: staticVariable.objectType[key],
-          value: (staticVariable.value as any)[key],
+          type: metadata.objectType[key],
+          value: (value as any)[key],
         };
-        initialValues.value_obj.push(value);
+        initialValues.value_obj.push(objectValue);
       }
       break;
     case StaticVariableComplexType.StringArray:
-      initialValues.value_arr_string = staticVariable.value as string[];
+      initialValues.value_arr_string = value as string[];
       break;
     case StaticVariableComplexType.NumberArray:
-      initialValues.value_arr_number = staticVariable.value as number[];
+      initialValues.value_arr_number = value as number[];
       break;
     case StaticVariableComplexType.BooleanArray:
-      initialValues.value_arr_boolean = staticVariable.value as boolean[];
+      initialValues.value_arr_boolean = value as boolean[];
       break;
     case StaticVariableComplexType.ObjectArray:
       // TODO - implement object array
@@ -81,38 +82,39 @@ export function buildInitialValues(staticVariable: StaticVariable) {
  * @param values The values from the StaticVariable form to process
  * @returns The processed and cleaned static variable values
  */
-export function processStaticValues(values: StaticVariable & StaticVariableFormValues) {
+export function processStaticValues(values: StaticVariableMetadata & StaticVariableFormValues) {
+  let value: StaticVariableValue = "";
   switch (values.variableType) {
     case StaticVariableScalarType.String:
-      values.value = values.value_string;
+      value = values.value_string;
       delete values.objectType;
       break;
     case StaticVariableScalarType.Number:
-      values.value = values.value_number;
+      value = values.value_number;
       delete values.objectType;
       break;
     case StaticVariableScalarType.Boolean:
-      values.value = values.value_boolean;
+      value = values.value_boolean;
       delete values.objectType;
       break;
     case StaticVariableComplexType.Object:
       values.objectType = {};
-      values.value = {};
-      for (const value of values.value_obj) {
-        values.objectType[value.key] = value.type;
-        values.value[value.key] = value.value;
+      value = {};
+      for (const objectValue of values.value_obj) {
+        values.objectType[objectValue.key] = objectValue.type;
+        value[objectValue.key] = objectValue.value;
       }
       break;
     case StaticVariableComplexType.StringArray:
-      values.value = values.value_arr_string;
+      value = values.value_arr_string;
       delete values.objectType;
       break;
     case StaticVariableComplexType.NumberArray:
-      values.value = values.value_arr_number;
+      value = values.value_arr_number;
       delete values.objectType;
       break;
     case StaticVariableComplexType.BooleanArray:
-      values.value = values.value_arr_boolean;
+      value = values.value_arr_boolean;
       delete values.objectType;
       break;
     case StaticVariableComplexType.ObjectArray:
@@ -127,14 +129,13 @@ export function processStaticValues(values: StaticVariable & StaticVariableFormV
   }
 
   // Packages up the values into a static variable
-  const staticVariable: StaticVariable = {
+  const metadata: StaticVariableMetadata = {
     name: values.name,
     key: values.key,
     description: values.description,
     variableType: values.variableType,
     objectType: values.objectType,
-    value: values.value,
   };
 
-  return staticVariable;
+  return { metadata, value };
 }


### PR DESCRIPTION
Splits a StaticVariable object into an object containing metadata and values in two separate subobjects for easier access within the actor sheet rendering

Depends on #254 